### PR TITLE
Fix missing call and site buttons in prospect cards

### DIFF
--- a/src/components/prospection/ProspectKanban.tsx
+++ b/src/components/prospection/ProspectKanban.tsx
@@ -5,7 +5,7 @@ import { mapProspectStatusToNoco } from '@/lib/prospectStatus';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Mail, Phone, Edit, Trash2 } from 'lucide-react';
+import { Mail, Phone, Edit, Trash2, Globe } from 'lucide-react';
 
 interface ProspectKanbanProps {
   prospects: Prospect[];
@@ -111,6 +111,12 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
                           <span>{p.phone}</span>
                         </div>
                       )}
+                      {p.website && (
+                        <div className="flex items-center gap-2">
+                          <Globe className="w-4 h-4" />
+                          <span>{p.website}</span>
+                        </div>
+                      )}
                     </div>
 
                     <div className="flex gap-2 pt-2 flex-wrap" onClick={e => e.stopPropagation()}>
@@ -122,15 +128,27 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
                           </a>
                         </Button>
                       )}
-                      {p.phone && (
-                        <Button size="sm" variant="secondary" className="gap-2" asChild>
-                          <a href={`tel:${p.phone}`}>
-                            <Phone className="w-4 h-4" />
-                            Appeler
-                          </a>
-                        </Button>
-                      )}
-                    </div>
+                    {p.phone && (
+                      <Button size="sm" variant="secondary" className="gap-2" asChild>
+                        <a href={`tel:${p.phone}`}>
+                          <Phone className="w-4 h-4" />
+                          Appeler
+                        </a>
+                      </Button>
+                    )}
+                    {p.website && (
+                      <Button size="sm" variant="outline" className="gap-2" asChild>
+                        <a
+                          href={p.website.startsWith('http') ? p.website : `https://${p.website}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          <Globe className="w-4 h-4" />
+                          Site
+                        </a>
+                      </Button>
+                    )}
+                  </div>
                   </CardContent>
                 </Card>
               ))}

--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -205,12 +205,16 @@ const Pipou = () => {
             (p as { telephone?: string }).telephone ||
             (p as { numero?: string }).numero ||
             (p as { phone?: string }).phone ||
+            (p as Record<string, string>)['t_l_phone'] ||
+            (p as Record<string, string>)['téléphone'] ||
             '',
           website:
             (p as Record<string, unknown>)[PROSPECT_SITE_COLUMN] as string ||
             (p as { site?: string }).site ||
             (p as { reseaux?: string }).reseaux ||
             (p as { website?: string }).website ||
+            (p as Record<string, string>)['reseaux_site'] ||
+            (p as Record<string, string>)['site_web'] ||
             '',
           status: mapProspectStatus((p as { status?: string }).status || 'nouveau'),
           lastContact:
@@ -237,7 +241,12 @@ const Pipou = () => {
         [PROSPECT_COMPANY_COLUMN]: newProspect.company,
         email: newProspect.email,
         [PROSPECT_PHONE_COLUMN]: newProspect.phone,
+        telephone: newProspect.phone,
+        phone: newProspect.phone,
         [PROSPECT_SITE_COLUMN]: newProspect.website,
+        site: newProspect.website,
+        reseaux: newProspect.website,
+        website: newProspect.website,
         status: mapProspectStatusToNoco('Nouveau'),
         dernier_contact: new Date().toISOString().split('T')[0]
       };
@@ -256,12 +265,16 @@ const Pipou = () => {
           (response as { telephone?: string }).telephone ||
           (response as { numero?: string }).numero ||
           (response as { phone?: string }).phone ||
+          (response as Record<string, string>)['t_l_phone'] ||
+          (response as Record<string, string>)['téléphone'] ||
           newProspect.phone,
         website:
           (response as Record<string, unknown>)[PROSPECT_SITE_COLUMN] as string ||
           (response as { site?: string }).site ||
           (response as { reseaux?: string }).reseaux ||
           (response as { website?: string }).website ||
+          (response as Record<string, string>)['reseaux_site'] ||
+          (response as Record<string, string>)['site_web'] ||
           newProspect.website,
         status: mapProspectStatus((response as { status?: string }).status || 'nouveau'),
         lastContact:
@@ -293,7 +306,12 @@ const Pipou = () => {
         [PROSPECT_COMPANY_COLUMN]: editingProspect.company,
         email: editingProspect.email,
         [PROSPECT_PHONE_COLUMN]: editingProspect.phone,
+        telephone: editingProspect.phone,
+        phone: editingProspect.phone,
         [PROSPECT_SITE_COLUMN]: editingProspect.website,
+        site: editingProspect.website,
+        reseaux: editingProspect.website,
+        website: editingProspect.website,
         status: mapProspectStatusToNoco(editingProspect.status),
         dernier_contact: editingProspect.lastContact
       });


### PR DESCRIPTION
## Summary
- Map more phone and website field variants when loading prospects so call and site buttons render
- Persist phone and website using multiple column keys on create and update
- Show prospect website and add Site button in Kanban cards

## Testing
- `npm run lint` *(fails: Unexpected any, require import)*
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68baf80878ec832d83e59f0b0d5e3709