### PR TITLE
Fix time stats for sub-hour durations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/components/overview/GlobalStats.tsx
+++ b/src/components/overview/GlobalStats.tsx
@@ -85,8 +85,17 @@ const GlobalStats = ({ stats, activeClients }: GlobalStatsProps) => {
       />
       <StatCard
         label="Temps"
-        value={`${stats.totalTimeSpent.toFixed(1)}h`}
-        subLabel="Total"
+        value={(() => {
+          const hours = Math.floor(stats.totalTimeSpent / 3600);
+          const minutes = Math.floor((stats.totalTimeSpent % 3600) / 60);
+          const seconds = Math.floor(stats.totalTimeSpent % 60);
+          const parts = [] as string[];
+          if (hours > 0) parts.push(`${hours}h`);
+          if (minutes > 0 || hours > 0) parts.push(`${minutes}m`);
+          parts.push(`${seconds}s`);
+          return parts.join(' ');
+        })()}
+        subLabel={`≈ ${(stats.totalTimeSpent / 3600).toFixed(2)}h`}
         icon={Clock}
       />
       <StatCard

--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -11,7 +11,7 @@ export interface GlobalStats {
   paidInvoices: number;
   totalRevenue: number;
   paidRevenue: number;
-  totalTimeSpent: number;
+  totalTimeSpent: number; // en secondes
   averageHourlyRate: number;
   isLoading: boolean;
 }
@@ -80,20 +80,26 @@ export const useGlobalStats = () => {
           .filter((i: any) => i.payée === true || i.payée === 'true' || i.paid === true)
           .reduce((acc: number, i: any) => acc + (Number(i.montant) || Number(i.amount) || 0), 0);
 
-        // Calculer le temps total passé sur les tâches
-        const totalMinutes = tasks.reduce((sum: number, task: any) => {
-          if (task.time_spent) {
-            const timeStr = task.time_spent.toString();
+        // Calculer le temps total passé sur les tâches (en secondes)
+        const totalSeconds = tasks.reduce((sum: number, task: any) => {
+          const time = task.time_spent;
+          if (!time) return sum;
+
+          if (typeof time === 'string') {
+            const timeStr = time.toString();
             if (timeStr.includes(':')) {
               const [hours, minutes, seconds] = timeStr.split(':').map(Number);
-              return sum + hours * 60 + minutes + seconds / 60;
+              return sum + hours * 3600 + minutes * 60 + seconds;
             }
-            return sum + parseFloat(timeStr) * 60;
+            // Format décimal d'heures
+            return sum + parseFloat(timeStr) * 3600;
           }
-          return sum;
+
+          // Rétrocompatibilité : temps stocké en minutes
+          return sum + Number(time) * 60;
         }, 0);
 
-        const totalHours = totalMinutes / 60;
+        const totalHours = totalSeconds / 3600;
         const averageHourlyRate = totalHours > 0 ? paidRevenue / totalHours : 0;
 
         setStats({
@@ -105,7 +111,7 @@ export const useGlobalStats = () => {
           paidInvoices,
           totalRevenue,
           paidRevenue,
-          totalTimeSpent: totalHours,
+          totalTimeSpent: totalSeconds,
           averageHourlyRate,
           isLoading: false
         });
@@ -119,7 +125,7 @@ export const useGlobalStats = () => {
           paidInvoices,
           totalRevenue,
           paidRevenue,
-          totalTimeSpent: totalHours,
+          totalTimeSpent: totalSeconds,
           averageHourlyRate
         });
 


### PR DESCRIPTION
## Summary
- compute task time totals in seconds and derive hourly rate accurately
- show elapsed time with seconds on dashboard stats
- add .gitignore for node_modules and build output

## Testing
- `npm run lint` (fails: Unexpected any...)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafde2ddf8832db18ab46b01cb85bf