### PR TITLE
Fix time stats for sub-hour durations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/src/components/overview/GlobalStats.tsx
+++ b/src/components/overview/GlobalStats.tsx
@@ -85,8 +85,17 @@ const GlobalStats = ({ stats, activeClients }: GlobalStatsProps) => {
       />
       <StatCard
         label="Temps"
-        value={`${stats.totalTimeSpent.toFixed(1)}h`}
-        subLabel="Total"
+        value={(() => {
+          const hours = Math.floor(stats.totalTimeSpent / 3600);
+          const minutes = Math.floor((stats.totalTimeSpent % 3600) / 60);
+          const seconds = Math.floor(stats.totalTimeSpent % 60);
+          const parts = [] as string[];
+          if (hours > 0) parts.push(`${hours}h`);
+          if (minutes > 0 || hours > 0) parts.push(`${minutes}m`);
+          parts.push(`${seconds}s`);
+          return parts.join(' ');
+        })()}
+        subLabel={`≈ ${(stats.totalTimeSpent / 3600).toFixed(2)}h`}
         icon={Clock}
       />
       <StatCard


### PR DESCRIPTION
## Summary
- compute task time totals in seconds and derive hourly rate accurately
- show elapsed time with seconds on dashboard stats
- add .gitignore for node_modules and build output
- hide hourly rate until at least one hour of work is tracked

## Testing
- `npm run lint` (fails: Unexpected any...)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bafde2ddf8832db18ab46b01cb85bf