### PR TITLE
Refactor project loading to set state once

### DIFF
--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -103,7 +103,7 @@ const Pipou = () => {
         const clientsRes = await nocodbService.getClients(true);
         const clients = (clientsRes.list || []) as NocoRecord[];
 
-        let first = true;
+        const loadedProjects: Project[] = [];
         await asyncPool(
           CONCURRENCY_LIMIT,
           clients,
@@ -155,18 +155,12 @@ const Pipou = () => {
             }
           },
           (project) => {
-            if (!project) return;
-            setProjects(prev => [...prev, project]);
-            if (first) {
-              first = false;
-              setIsLoadingProjects(false);
-            }
+            if (project) loadedProjects.push(project);
           }
         );
 
-        if (first) {
-          setIsLoadingProjects(false);
-        }
+        setProjects(loadedProjects);
+        setIsLoadingProjects(false);
       } catch (error) {
         console.error('Erreur chargement projets:', error);
         setIsLoadingProjects(false);


### PR DESCRIPTION
## Summary
- collect asyncPool results in a local array before updating state
- remove incremental project loading and `first` flag

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bb07f5c6c0832dae014c43e7323e64