### PR TITLE
Remove progress stats from Pipou project cards

### DIFF
--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -15,7 +15,6 @@ import { Prospect } from '@/types/prospect';
 import { mapProspectStatus, mapProspectStatusToNoco } from '@/lib/prospectStatus';
 import MilestoneManager from '@/components/milestones/MilestoneManager';
 import NocoInvoiceManager from '@/components/invoices/NocoInvoiceManager';
-import { Progress } from '@/components/ui/progress';
 
 type NocoRecord = Record<string, unknown>;
 
@@ -32,51 +31,13 @@ interface Project {
   deadline: string;
   progress: number;
   description: string;
-  tasksCount: number;
-  milestonesCount: number;
-  invoicesCount: number;
   driveLink: string;
   price: number;
 }
 
-const CONCURRENCY_LIMIT = 3;
 const PROSPECTS_PAGE_SIZE = 20;
 
-async function asyncPool<T, R>(
-  limit: number,
-  array: T[],
-  iteratorFn: (item: T) => Promise<R>,
-  onResult?: (result: R) => void
-): Promise<R[]> {
-  const ret: R[] = [];
-  let i = 0;
-
-  const workers = Array.from({ length: Math.min(limit, array.length) }, async () => {
-    while (i < array.length) {
-      const currentIndex = i++;
-      const res = await iteratorFn(array[currentIndex]);
-      ret[currentIndex] = res;
-      onResult?.(res);
-    }
-  });
-
-  await Promise.all(workers);
-  return ret;
-}
-
-async function fetchWithRetry<T>(fn: () => Promise<T>, retries = 3, delay = 1000): Promise<T> {
-  try {
-    return await fn();
-  } catch (error: unknown) {
-    const err = error as { status?: number; message?: string };
-    const isRateLimited = err?.status === 429 || (err?.message || '').includes('429');
-    if (retries > 0 && isRateLimited) {
-      await new Promise(resolve => setTimeout(resolve, delay));
-      return fetchWithRetry(fn, retries - 1, delay * 2);
-    }
-    throw error;
-  }
-}
+// Fonction utilitaire supprimée : les appels réseau sont limités
 
 const Pipou = () => {
   const { hasFeatureAccess, upgradeRequired, loading } = usePlan();
@@ -102,11 +63,6 @@ const Pipou = () => {
       try {
         const clientsRes = await nocodbService.getClients();
         const clients = (clientsRes.list || []) as NocoRecord[];
-        const clientIds = clients
-          .map(c => ((c as { Id?: unknown; id?: unknown }).Id || (c as { Id?: unknown; id?: unknown }).id)?.toString() || '')
-          .filter(Boolean);
-
-        const stats = await fetchWithRetry(() => nocodbService.getProjectsWithStats(clientIds));
 
         const projectsData = clients.map(c => {
           const clientId = ((c as { Id?: unknown; id?: unknown }).Id || (c as { Id?: unknown; id?: unknown }).id)?.toString() || '';
@@ -120,9 +76,6 @@ const Pipou = () => {
           const driveLink = (record['lien_portail'] as string) || '';
           const price = (record['prix_payement'] as number) || 0;
 
-          const stat = stats[clientId] || { tasksCount: 0, milestonesCount: 0, invoicesCount: 0, doneMilestones: 0 };
-          const progress = stat.milestonesCount > 0 ? Math.round((stat.doneMilestones / stat.milestonesCount) * 100) : 0;
-
           return {
             id: clientId,
             projectId: clientId,
@@ -130,75 +83,14 @@ const Pipou = () => {
             spaceName,
             status,
             deadline,
-            progress,
+            progress: 0,
             description: desc,
-            tasksCount: stat.tasksCount,
-            milestonesCount: stat.milestonesCount,
-            invoicesCount: stat.invoicesCount,
             driveLink,
             price
           } as Project;
         });
 
         setProjects(projectsData);
-
-        const loadedProjects: Project[] = [];
-        await asyncPool(
-          CONCURRENCY_LIMIT,
-          clients,
-          async (c) => {
-            try {
-              const clientId = ((c as { Id?: unknown; id?: unknown }).Id || (c as { Id?: unknown; id?: unknown }).id)?.toString() || '';
-              const [tasksCount, milestonesRes, invoicesCount] = await Promise.all([
-                fetchWithRetry(() => nocodbService.getTasksCount(clientId, { onlyCurrentUser: true })),
-                fetchWithRetry(() => nocodbService.getMilestones(clientId, { fields: 'terminé,termine' })),
-                fetchWithRetry(() => nocodbService.getInvoicesCount(clientId))
-              ]);
-
-              const milestonesList = (milestonesRes.list || []) as NocoRecord[];
-              const doneMilestones = milestonesList.filter((m: NocoRecord) => {
-                const status = (m as { terminé?: unknown; termine?: unknown }).terminé || (m as { terminé?: unknown; termine?: unknown }).termine;
-                return status === true || status === 'true';
-              }).length;
-              const progress = milestonesList.length > 0 ? Math.round((doneMilestones / milestonesList.length) * 100) : 0;
-
-              const record = c as Record<string, unknown>;
-              const name = (record.nom as string) || (record.name as string) || 'Client';
-              const desc = (record.description as string) || '';
-
-              const spaceName = desc || name;
-              const status = (record.statut as string) || 'En cours';
-              const rawDeadline = (record.deadline as string) || '';
-              const deadline = rawDeadline ? new Date(rawDeadline).toLocaleDateString() : 'Aucune';
-              const driveLink = (record['lien_portail'] as string) || '';
-              const price = (record['prix_payement'] as number) || 0;
-
-              return {
-                id: clientId,
-                projectId: clientId,
-                client: name,
-                spaceName,
-                status,
-                deadline,
-                progress,
-                description: desc,
-                tasksCount: tasksCount,
-                milestonesCount: milestonesRes.pageInfo?.totalRows ?? milestonesList.length,
-                invoicesCount: invoicesCount,
-                driveLink,
-                price
-              } as Project;
-            } catch (error) {
-              console.error('Erreur chargement client:', error);
-              return null;
-            }
-          },
-          (project) => {
-            if (project) loadedProjects.push(project);
-          }
-        );
-
-        setProjects(loadedProjects);
         setIsLoadingProjects(false);
       } catch (error) {
         console.error('Erreur chargement projets:', error);
@@ -396,21 +288,8 @@ const Pipou = () => {
     alert(`✉️ Message automatique pour ${project.client}:\n\n"Bonjour ! Voici un point sur l'avancement de votre projet '${project.spaceName}'.\n\nNous avons bien progressé avec ${project.progress}% de réalisation. L'équipe travaille actuellement sur les derniers ajustements pour respecter votre deadline du ${project.deadline}.\n\nN'hésite pas si tu as des questions !\nL'équipe Lumina 🚀"`);
   };
 
-  const refreshProjectData = async (projectId: string) => {
-    try {
-      const stats = await fetchWithRetry(() => nocodbService.getProjectsWithStats([projectId]));
-      const stat = stats[projectId] || { tasksCount: 0, milestonesCount: 0, invoicesCount: 0, doneMilestones: 0 };
-      const progress = stat.milestonesCount > 0 ? Math.round((stat.doneMilestones / stat.milestonesCount) * 100) : 0;
-      setProjects(prev => prev.map(p => p.id === projectId ? {
-        ...p,
-        tasksCount: stat.tasksCount,
-        milestonesCount: stat.milestonesCount,
-        invoicesCount: stat.invoicesCount,
-        progress
-      } : p));
-    } catch (error) {
-      console.error('Erreur rafraîchissement projet:', error);
-    }
+  const refreshProjectData = async (_projectId: string) => {
+    // Les statistiques de projet ne sont plus chargées
   };
 
   return (
@@ -463,18 +342,6 @@ const Pipou = () => {
                           <p className="text-sm text-muted-foreground">
                             {project.description}
                           </p>
-                          <div className="space-y-2">
-                            <div className="flex justify-between text-sm">
-                              <span>Avancement</span>
-                              <span className="font-medium">{project.progress}%</span>
-                            </div>
-                            <Progress value={project.progress} />
-                          </div>
-                          <div className="grid grid-cols-3 gap-2 text-sm">
-                            <div><span className="font-medium">{project.tasksCount}</span> tâches</div>
-                            <div><span className="font-medium">{project.milestonesCount}</span> jalons</div>
-                            <div><span className="font-medium">{project.invoicesCount}</span> factures</div>
-                          </div>
                           <div className="flex gap-2 pt-2 flex-wrap">
                             <Button
                               size="sm"


### PR DESCRIPTION
## Summary
- Simplify Pipou project listing by omitting progress and count stats
- Drop extra NocoDB requests for tasks, milestones and invoices
- Keep essential project action buttons only

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, require())*


------
https://chatgpt.com/codex/tasks/task_e_68bb0a0f7e18832d980b9fca2e271a9d