### PR TITLE
Simplify prospect displays

### DIFF
--- a/src/components/prospection/ProspectKanban.tsx
+++ b/src/components/prospection/ProspectKanban.tsx
@@ -5,7 +5,7 @@ import { mapProspectStatusToNoco } from '@/lib/prospectStatus';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Mail, Phone, Edit, Trash2, Globe } from 'lucide-react';
+import { Mail, Phone, Edit, Trash2 } from 'lucide-react';
 
 interface ProspectKanbanProps {
   prospects: Prospect[];
@@ -70,9 +70,6 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
                     <div className="flex justify-between items-start">
                       <div>
                         <h4 className="font-medium">{p.name}</h4>
-                        {p.company && (
-                          <p className="text-sm text-muted-foreground">{p.company}</p>
-                        )}
                       </div>
                       <div className="flex gap-1" onClick={e => e.stopPropagation()}>
                         <Button
@@ -98,27 +95,6 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
                       </div>
                     </div>
 
-                    <div className="space-y-1 text-sm text-muted-foreground">
-                      {p.email && (
-                        <div className="flex items-center gap-2">
-                          <Mail className="w-4 h-4" />
-                          <span>{p.email}</span>
-                        </div>
-                      )}
-                      {p.phone && (
-                        <div className="flex items-center gap-2">
-                          <Phone className="w-4 h-4" />
-                          <span>{p.phone}</span>
-                        </div>
-                      )}
-                      {p.website && (
-                        <div className="flex items-center gap-2">
-                          <Globe className="w-4 h-4" />
-                          <span>{p.website}</span>
-                        </div>
-                      )}
-                    </div>
-
                     <div className="flex gap-2 pt-2 flex-wrap" onClick={e => e.stopPropagation()}>
                       {p.email && (
                         <Button size="sm" className="gap-2" asChild>
@@ -128,27 +104,15 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
                           </a>
                         </Button>
                       )}
-                    {p.phone && (
-                      <Button size="sm" variant="secondary" className="gap-2" asChild>
-                        <a href={`tel:${p.phone}`}>
-                          <Phone className="w-4 h-4" />
-                          Appeler
-                        </a>
-                      </Button>
-                    )}
-                    {p.website && (
-                      <Button size="sm" variant="outline" className="gap-2" asChild>
-                        <a
-                          href={p.website.startsWith('http') ? p.website : `https://${p.website}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          <Globe className="w-4 h-4" />
-                          Site
-                        </a>
-                      </Button>
-                    )}
-                  </div>
+                      {p.phone && (
+                        <Button size="sm" variant="secondary" className="gap-2" asChild>
+                          <a href={`tel:${p.phone}`}>
+                            <Phone className="w-4 h-4" />
+                            Appeler
+                          </a>
+                        </Button>
+                      )}
+                    </div>
                   </CardContent>
                 </Card>
               ))}

--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -142,6 +142,7 @@ const Pipou = () => {
           (p as { phone?: string }).phone ||
           (p as Record<string, string>)['t_l_phone'] ||
           (p as Record<string, string>)['téléphone'] ||
+          (p as Record<string, string>)['Téléphone'] ||
           '',
         website:
           (p as Record<string, unknown>)[PROSPECT_SITE_COLUMN] as string ||
@@ -182,6 +183,7 @@ const Pipou = () => {
         [PROSPECT_PHONE_COLUMN]: newProspect.phone,
         telephone: newProspect.phone,
         phone: newProspect.phone,
+        Téléphone: newProspect.phone,
         [PROSPECT_SITE_COLUMN]: newProspect.website,
         site: newProspect.website,
         reseaux: newProspect.website,
@@ -206,6 +208,7 @@ const Pipou = () => {
           (response as { phone?: string }).phone ||
           (response as Record<string, string>)['t_l_phone'] ||
           (response as Record<string, string>)['téléphone'] ||
+          (response as Record<string, string>)['Téléphone'] ||
           newProspect.phone,
         website:
           (response as Record<string, unknown>)[PROSPECT_SITE_COLUMN] as string ||
@@ -248,6 +251,7 @@ const Pipou = () => {
         [PROSPECT_PHONE_COLUMN]: editingProspect.phone,
         telephone: editingProspect.phone,
         phone: editingProspect.phone,
+        Téléphone: editingProspect.phone,
         [PROSPECT_SITE_COLUMN]: editingProspect.website,
         site: editingProspect.website,
         reseaux: editingProspect.website,
@@ -425,11 +429,6 @@ const Pipou = () => {
                             <div className="flex items-start justify-between">
                               <div>
                                 <CardTitle className="text-lg">{prospect.name}</CardTitle>
-                                {prospect.company && (
-                                  <p className="mt-2 text-sm text-muted-foreground">
-                                    {prospect.company}
-                                  </p>
-                                )}
                               </div>
                               <div className="flex items-center gap-2">
                                 {prospect.status && (
@@ -470,40 +469,7 @@ const Pipou = () => {
                               <span>Téléphone</span>
                               <span className="font-medium">{prospect.phone}</span>
                             </div>
-                            <div className="flex justify-between">
-                              <span>Réseaux / Site</span>
-                              <span className="font-medium">{prospect.website}</span>
-                            </div>
-                            <div className="flex gap-2 pt-2 flex-wrap">
-                              {prospect.email && (
-                                <Button size="sm" className="gap-2" asChild>
-                                  <a href={`mailto:${prospect.email}`}>
-                                    <Mail className="w-4 h-4" />
-                                    Contacter
-                                  </a>
-                                </Button>
-                              )}
-                              {prospect.phone && (
-                                <Button size="sm" variant="secondary" className="gap-2" asChild>
-                                  <a href={`tel:${prospect.phone}`}>
-                                    <Phone className="w-4 h-4" />
-                                    Appeler
-                                  </a>
-                                </Button>
-                              )}
-                              {prospect.website && (
-                                <Button size="sm" variant="outline" className="gap-2" asChild>
-                                  <a
-                                    href={prospect.website.startsWith('http') ? prospect.website : `https://${prospect.website}`}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                  >
-                                    <Globe className="w-4 h-4" />
-                                    Site
-                                  </a>
-                                </Button>
-                              )}
-                            </div>
+                            
                           </CardContent>
                         </Card>
                       ))}


### PR DESCRIPTION
## Summary
- Show only prospect name, status, email and phone in list view
- Reduce Kanban card content to name with edit/delete and contact/call actions
- Handle capitalized "Téléphone" field so phone numbers persist when loading, creating and updating prospects

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any, @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0c7c128c832d8de7520d0bbe3d3c