### PR TITLE
Optimize NocoDB data loading for client view

### DIFF
--- a/src/components/overview/StatisticsOverview.tsx
+++ b/src/components/overview/StatisticsOverview.tsx
@@ -10,11 +10,12 @@ import MarginManager from '@/components/finances/MarginManager';
 
 interface StatisticsOverviewProps {
   spaceId: string;
+  isPublic?: boolean;
 }
 
-const StatisticsOverview = ({ spaceId }: StatisticsOverviewProps) => {
+const StatisticsOverview = ({ spaceId, isPublic = false }: StatisticsOverviewProps) => {
   const globalStats = useGlobalStats();
-  const spaceData = useSpaceData(spaceId);
+  const spaceData = useSpaceData(spaceId, isPublic);
   const marginStats = useMarginStats();
 
   // Utiliser les données appropriées (spécifiques à l'espace ou globales)

--- a/src/components/tasks/TaskManager.tsx
+++ b/src/components/tasks/TaskManager.tsx
@@ -35,7 +35,7 @@ const TaskManager = ({
   onDataChange
 }: TaskManagerProps) => {
   const { toast } = useToast();
-  const spaceData = useSpaceData(projetId);
+  const spaceData = useSpaceData(projetId, isClient);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [editingTask, setEditingTask] = useState<Task | null>(null);

--- a/src/pages/ClientView.tsx
+++ b/src/pages/ClientView.tsx
@@ -295,7 +295,7 @@ const ClientView = () => {
             </div>
           )}
 
-          <StatisticsOverview spaceId={id || ''} />
+          <StatisticsOverview spaceId={id || ''} isPublic />
 
           {space.onboardingLink && space.onboardingLink.trim() && (
             <Card>
@@ -318,7 +318,7 @@ const ClientView = () => {
         </TabsContent>
 
         <TabsContent value="project" className="container mx-auto px-4 py-6 space-y-6">
-          <StatisticsOverview spaceId={id || ''} />
+          <StatisticsOverview spaceId={id || ''} isPublic />
           <Tabs defaultValue="tasks" className="w-full">
             <TabsList className="justify-start mb-4">
               {projectNavItems.map((item) => (


### PR DESCRIPTION
## Summary
- fetch space tasks, milestones, and invoices in one parallel request via nocodbService
- allow useSpaceData and StatisticsOverview to handle public client views
- ensure TaskManager uses client-aware data loading

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Unexpected any and other lint errors)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb15b43df8832d92017b0f4de82f8b