### PR TITLE
feat: expand prospect kanban to five columns

### DIFF
--- a/src/components/prospection/ProspectKanban.tsx
+++ b/src/components/prospection/ProspectKanban.tsx
@@ -18,6 +18,7 @@ const statuses = [
   { id: 'Nouveau', title: 'Nouveau', color: 'bg-gray-100 dark:bg-gray-800' },
   { id: 'En contact', title: 'En contact', color: 'bg-blue-100 dark:bg-blue-900/30' },
   { id: 'En discussion', title: 'En discussion', color: 'bg-yellow-100 dark:bg-yellow-900/30' },
+  { id: 'Proposition', title: 'Proposition', color: 'bg-purple-100 dark:bg-purple-900/30' },
   { id: 'Converti', title: 'Converti', color: 'bg-green-100 dark:bg-green-900/30' },
 ];
 
@@ -42,7 +43,7 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
   };
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
       {statuses.map(column => (
         <div
           key={column.id}

--- a/src/lib/prospectStatus.ts
+++ b/src/lib/prospectStatus.ts
@@ -6,6 +6,8 @@ export const mapProspectStatus = (status: string) => {
       return 'En contact';
     case 'en discussion':
       return 'En discussion';
+    case 'proposition':
+      return 'Proposition';
     case 'converti':
       return 'Converti';
     default:
@@ -21,6 +23,8 @@ export const mapProspectStatusToNoco = (status: string) => {
       return 'en contact';
     case 'En discussion':
       return 'en discussion';
+    case 'Proposition':
+      return 'proposition';
     case 'Converti':
       return 'converti';
     default:


### PR DESCRIPTION
## Summary
- add `Proposition` stage to prospect status mapping
- extend prospect kanban to five columns with new `Proposition` column

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, Fast refresh warnings, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2684e91c832d8e9d5e0899f3466c