### PR TITLE
feat: expand prospect kanban and fix prospect form saving

### DIFF
--- a/src/components/prospection/ProspectForm.tsx
+++ b/src/components/prospection/ProspectForm.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+export interface ProspectFormData {
+  name: string;
+  company: string;
+  email: string;
+  phone: string;
+  website: string;
+}
+
+interface ProspectFormProps {
+  initialData?: ProspectFormData;
+  onSubmit: (data: ProspectFormData) => void;
+  onCancel: () => void;
+  submitLabel?: string;
+}
+
+const ProspectForm = ({ initialData, onSubmit, onCancel, submitLabel = 'Enregistrer' }: ProspectFormProps) => {
+  const [formData, setFormData] = useState<ProspectFormData>(
+    initialData || { name: '', company: '', email: '', phone: '', website: '' }
+  );
+
+  const handleChange = (field: keyof ProspectFormData) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFormData({ ...formData, [field]: e.target.value });
+  };
+
+  const handleSubmit = () => {
+    onSubmit(formData);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="space-y-2">
+        <Label htmlFor="prospect-name">Nom</Label>
+        <Input id="prospect-name" value={formData.name} onChange={handleChange('name')} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="prospect-company">Entreprise</Label>
+        <Input id="prospect-company" value={formData.company} onChange={handleChange('company')} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="prospect-email">Email</Label>
+        <Input id="prospect-email" type="email" value={formData.email} onChange={handleChange('email')} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="prospect-phone">Téléphone</Label>
+        <Input id="prospect-phone" value={formData.phone} onChange={handleChange('phone')} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="prospect-website">Réseaux / Site</Label>
+        <Input id="prospect-website" value={formData.website} onChange={handleChange('website')} />
+      </div>
+      <div className="flex justify-end gap-3 mt-4">
+        <Button variant="outline" onClick={onCancel}>
+          Annuler
+        </Button>
+        <Button onClick={handleSubmit}>{submitLabel}</Button>
+      </div>
+    </div>
+  );
+};
+
+export default ProspectForm;

--- a/src/components/prospection/ProspectKanban.tsx
+++ b/src/components/prospection/ProspectKanban.tsx
@@ -18,6 +18,7 @@ const statuses = [
   { id: 'Nouveau', title: 'Nouveau', color: 'bg-gray-100 dark:bg-gray-800' },
   { id: 'En contact', title: 'En contact', color: 'bg-blue-100 dark:bg-blue-900/30' },
   { id: 'En discussion', title: 'En discussion', color: 'bg-yellow-100 dark:bg-yellow-900/30' },
+  { id: 'Proposition', title: 'Proposition', color: 'bg-purple-100 dark:bg-purple-900/30' },
   { id: 'Converti', title: 'Converti', color: 'bg-green-100 dark:bg-green-900/30' },
 ];
 
@@ -42,7 +43,7 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
   };
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 md:grid-cols-5 gap-4">
       {statuses.map(column => (
         <div
           key={column.id}

--- a/src/lib/prospectStatus.ts
+++ b/src/lib/prospectStatus.ts
@@ -6,6 +6,8 @@ export const mapProspectStatus = (status: string) => {
       return 'En contact';
     case 'en discussion':
       return 'En discussion';
+    case 'proposition':
+      return 'Proposition';
     case 'converti':
       return 'Converti';
     default:
@@ -21,6 +23,8 @@ export const mapProspectStatusToNoco = (status: string) => {
       return 'en contact';
     case 'En discussion':
       return 'en discussion';
+    case 'Proposition':
+      return 'proposition';
     case 'Converti':
       return 'converti';
     default:


### PR DESCRIPTION
## Summary
- add `Proposition` stage to prospect status mapping
- extend prospect kanban to five columns with new `Proposition` column
- rebuild prospect creation/edit form and ensure company, phone and site save correctly to NocoDB

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2684e91c832d8e9d5e0899f3466c