### PR TITLE
Hide client-assigned tasks in Tasky client view

### DIFF
--- a/src/pages/Tasky.tsx
+++ b/src/pages/Tasky.tsx
@@ -151,6 +151,16 @@ const Tasky = () => {
           list = (res.list || []).map((t: any) => ({ ...t, isInternal: false }));
         }
 
+        if (taskScope === 'client') {
+          list = list.filter((t: any) => {
+            const responsible = (t.responsable || t.responsible || '')
+              .toString()
+              .trim()
+              .toLowerCase();
+            return !responsible.includes('client');
+          });
+        }
+
         const tasksWithNames = list.map((t: any) => ({
           ...t,
           id: t.Id || t.id,


### PR DESCRIPTION
## Summary
- Prevent client view from showing tasks assigned to the client

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: various ESLint errors including "Unexpected any" and hook-order issues)


------
https://chatgpt.com/codex/tasks/task_e_68bb44c9abac832db2a808c964dfd77b