### PR TITLE
feat: add user branding service and schema

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -35,6 +35,33 @@ export type Database = {
         }
         Relationships: []
       }
+      user_branding: {
+        Row: {
+          user_id: string
+          company_name: string | null
+          primary_color: string | null
+          secondary_color: string | null
+          logo_url: string | null
+          created_at: string
+        }
+        Insert: {
+          user_id: string
+          company_name?: string | null
+          primary_color?: string | null
+          secondary_color?: string | null
+          logo_url?: string | null
+          created_at?: string
+        }
+        Update: {
+          user_id?: string
+          company_name?: string | null
+          primary_color?: string | null
+          secondary_color?: string | null
+          logo_url?: string | null
+          created_at?: string
+        }
+        Relationships: []
+      }
       user_plans: {
         Row: {
           active_spaces_count: number

--- a/src/services/brandingService.ts
+++ b/src/services/brandingService.ts
@@ -1,0 +1,54 @@
+import { supabase } from '@/integrations/supabase/client';
+
+export interface UserBranding {
+  company_name?: string | null;
+  primary_color?: string | null;
+  secondary_color?: string | null;
+  logo_url?: string | null;
+}
+
+class BrandingService {
+  private async getCurrentUserId(): Promise<string | null> {
+    const { data: { user } } = await supabase.auth.getUser();
+    return user?.id ?? null;
+  }
+
+  async getBranding(): Promise<UserBranding | null> {
+    const userId = await this.getCurrentUserId();
+    if (!userId) return null;
+
+    const { data, error } = await supabase
+      .from('user_branding')
+      .select('company_name, primary_color, secondary_color, logo_url')
+      .eq('user_id', userId)
+      .single();
+
+    if (error) {
+      console.error('Error fetching branding:', error);
+      return null;
+    }
+
+    return data as UserBranding;
+  }
+
+  async upsertBranding(branding: UserBranding): Promise<UserBranding | null> {
+    const userId = await this.getCurrentUserId();
+    if (!userId) return null;
+
+    const { data, error } = await supabase
+      .from('user_branding')
+      .upsert({ user_id: userId, ...branding })
+      .select('company_name, primary_color, secondary_color, logo_url')
+      .single();
+
+    if (error) {
+      console.error('Error updating branding:', error);
+      return null;
+    }
+
+    return data as UserBranding;
+  }
+}
+
+export const brandingService = new BrandingService();
+export default brandingService;

--- a/supabase/migrations/20250824120000_user_branding.sql
+++ b/supabase/migrations/20250824120000_user_branding.sql
@@ -1,0 +1,33 @@
+-- Create user_branding table for storing branding preferences per user
+create table if not exists public.user_branding (
+  user_id uuid primary key references auth.users(id),
+  company_name text,
+  primary_color text,
+  secondary_color text,
+  logo_url text,
+  created_at timestamptz not null default now()
+);
+
+alter table public.user_branding enable row level security;
+
+-- Policies: users can manage only their own branding data
+create policy "Users can view own branding" on public.user_branding
+  for select
+  to authenticated
+  using (auth.uid() = user_id);
+
+create policy "Users can insert own branding" on public.user_branding
+  for insert
+  to authenticated
+  with check (auth.uid() = user_id);
+
+create policy "Users can update own branding" on public.user_branding
+  for update
+  to authenticated
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+create policy "Users can delete own branding" on public.user_branding
+  for delete
+  to authenticated
+  using (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- add user_branding table with RLS policies
- implement service to manage user branding data
- extend Supabase types for user_branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4d0f86e4832dba8efbc1e1dad4ef