### PR TITLE
feat: add branding customization

### DIFF
--- a/src/components/layout/ClientNavigation.tsx
+++ b/src/components/layout/ClientNavigation.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Bot, ChevronLeft, ChevronRight, Menu, ExternalLink, Moon, Sun } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
 import { cn } from '@/lib/utils';
 import { useIsMobile } from '@/hooks/use-mobile';
+import { loadBranding, applyBranding } from '@/lib/branding';
 
 interface ClientNavigationProps {
   spaceName?: string;
@@ -16,6 +17,11 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
   const [collapsed, setCollapsed] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isDark, setIsDark] = useState(false);
+  const branding = loadBranding();
+
+  useEffect(() => {
+    applyBranding(branding);
+  }, []);
 
   const toggleTheme = () => {
     setIsDark(!isDark);
@@ -38,7 +44,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
           </div>
           {(!collapsed || isMobile) && (
             <div>
-              <h1 className="text-xl font-bold bg-gradient-primary bg-clip-text text-transparent">Lumina</h1>
+              <h1 className="text-xl font-bold bg-gradient-primary bg-clip-text text-transparent">{branding.brandName || 'Lumina'}</h1>
               <p className="text-sm text-muted-foreground">Espace Client</p>
             </div>
           )}
@@ -62,7 +68,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
       {/* Footer */}
       <div className="flex-shrink-0 border-t border-border/50 bg-background">
         <div className={cn('space-y-2', collapsed && !isMobile ? 'p-2' : 'p-6 pt-4')}>
-          {/* Découvrir Lumina */}
+          {/* Découvrir */}
           <Button
             variant="outline"
             size="sm"
@@ -70,7 +76,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
             className={cn('w-full justify-start gap-3 text-muted-foreground', collapsed && !isMobile && 'justify-center px-2')}
           >
             <ExternalLink className="w-4 h-4" />
-            {(!collapsed || isMobile) && 'Découvrir Lumina'}
+            {(!collapsed || isMobile) && `Découvrir ${branding.brandName || 'Lumina'}`}
           </Button>
 
           {/* Dark mode toggle */}
@@ -111,7 +117,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
               <Bot className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h1 className="text-lg font-bold bg-gradient-primary bg-clip-text text-transparent">Lumina</h1>
+              <h1 className="text-lg font-bold bg-gradient-primary bg-clip-text text-transparent">{branding.brandName || 'Lumina'}</h1>
               {spaceName && (
                 <p className="text-xs text-muted-foreground truncate max-w-32">{spaceName}</p>
               )}

--- a/src/lib/branding.ts
+++ b/src/lib/branding.ts
@@ -1,0 +1,63 @@
+export interface BrandingSettings {
+  brandName?: string;
+  brandColor?: string;
+}
+
+export const loadBranding = (): BrandingSettings => {
+  try {
+    return JSON.parse(localStorage.getItem('branding') || '{}');
+  } catch {
+    return {};
+  }
+};
+
+export const saveBranding = (settings: BrandingSettings) => {
+  localStorage.setItem('branding', JSON.stringify(settings));
+};
+
+const hexToHSL = (hex: string): string => {
+  let r = 0, g = 0, b = 0;
+  const cleanHex = hex.replace('#', '');
+  if (cleanHex.length === 3) {
+    r = parseInt(cleanHex[0] + cleanHex[0], 16);
+    g = parseInt(cleanHex[1] + cleanHex[1], 16);
+    b = parseInt(cleanHex[2] + cleanHex[2], 16);
+  } else if (cleanHex.length === 6) {
+    r = parseInt(cleanHex.substring(0, 2), 16);
+    g = parseInt(cleanHex.substring(2, 4), 16);
+    b = parseInt(cleanHex.substring(4, 6), 16);
+  }
+  r /= 255;
+  g /= 255;
+  b /= 255;
+  const max = Math.max(r, g, b), min = Math.min(r, g, b);
+  let h = 0, s = 0;
+  const l = (max + min) / 2;
+  if (max !== min) {
+    const d = max - min;
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
+    }
+    h /= 6;
+  }
+  return `${Math.round(h * 360)} ${Math.round(s * 100)}% ${Math.round(l * 100)}%`;
+};
+
+export const applyBranding = (settings?: BrandingSettings) => {
+  const branding = settings || loadBranding();
+  if (branding.brandColor) {
+    const hsl = hexToHSL(branding.brandColor);
+    const root = document.documentElement.style;
+    root.setProperty('--primary', hsl);
+    root.setProperty('--primary-glow', hsl);
+  }
+};

--- a/src/pages/ClientAccess.tsx
+++ b/src/pages/ClientAccess.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -7,6 +7,7 @@ import { ArrowRight, Users, Lock } from 'lucide-react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
 import { clientAuthService } from '@/services/clientAuthService';
+import { loadBranding, applyBranding } from '@/lib/branding';
 
 const ClientAccess = () => {
   const [token, setToken] = useState('');
@@ -14,6 +15,11 @@ const ClientAccess = () => {
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
   const { toast } = useToast();
+  const branding = loadBranding();
+
+  useEffect(() => {
+    applyBranding(branding);
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -173,10 +179,10 @@ const ClientAccess = () => {
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
           <Link to="/" className="flex items-center gap-3">
             <div className="w-10 h-10 rounded-lg bg-gradient-primary flex items-center justify-center shadow-glow bg-black">
-              <img src="/lovable-uploads/cb6c54cf-a6f8-4ef1-aca0-b5011c552548.png" alt="Lumina Logo" className="w-6 h-6" />
+              <img src="/lovable-uploads/cb6c54cf-a6f8-4ef1-aca0-b5011c552548.png" alt={`${branding.brandName || 'Lumina'} Logo`} className="w-6 h-6" />
             </div>
             <span className="text-xl font-bold bg-gradient-primary bg-clip-text text-transparent">
-              Lumina
+              {branding.brandName || 'Lumina'}
             </span>
           </Link>
           <Link to="/auth">

--- a/src/pages/ClientView.tsx
+++ b/src/pages/ClientView.tsx
@@ -28,6 +28,7 @@ import MilestoneManager from '@/components/milestones/MilestoneManager';
 import InvoiceManager from '@/components/invoices/InvoiceManager';
 import nocodbService from '@/services/nocodbService';
 import clientAuthService from '@/services/clientAuthService';
+import { loadBranding, applyBranding } from '@/lib/branding';
 
 const navItems = [
   { value: 'home', icon: Home, label: 'Accueil' },
@@ -35,11 +36,6 @@ const navItems = [
   { value: 'collaborator', icon: Users, label: 'Collaborateur' }
 ];
 
-const providerInfo = {
-  name: 'Lumina',
-  website: 'https://lumina.app',
-  email: 'contact@lumina.app'
-};
 
 const ClientView = () => {
   const { id } = useParams();
@@ -50,6 +46,15 @@ const ClientView = () => {
   const [passwordInput, setPasswordInput] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [needsPassword, setNeedsPassword] = useState(false);
+  const branding = loadBranding();
+  useEffect(() => {
+    applyBranding(branding);
+  }, []);
+  const providerInfo = {
+    name: branding.brandName || 'Lumina',
+    website: 'https://lumina.app',
+    email: 'contact@lumina.app'
+  };
 
   useEffect(() => {
     const loadSpace = async () => {

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -19,12 +19,14 @@ import {
   X,
   CheckCircle,
   AlertTriangle,
-  Link as LinkIcon
+  Link as LinkIcon,
+  Palette
 } from 'lucide-react';
 import { usePlan } from '@/contexts/PlanContext';
 import { useAuth } from '@/contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
+import { loadBranding, saveBranding } from '@/lib/branding';
 
 const Profile = () => {
   const { user, changePassword } = useAuth();
@@ -39,7 +41,9 @@ const Profile = () => {
     darkMode: false,
     paymentLink: '',
     messageLink: '',
-    meetingLink: ''
+    meetingLink: '',
+    brandName: '',
+    brandColor: '#895af6'
   });
 
   const [isPasswordEditing, setIsPasswordEditing] = useState(false);
@@ -50,11 +54,14 @@ const Profile = () => {
 
   useEffect(() => {
     const savedLinks = JSON.parse(localStorage.getItem('defaultLinks') || '{}');
+    const savedBranding = loadBranding();
     setFormData(prev => ({
       ...prev,
       paymentLink: savedLinks.paymentLink || '',
       messageLink: savedLinks.messageLink || '',
-      meetingLink: savedLinks.meetingLink || ''
+      meetingLink: savedLinks.meetingLink || '',
+      brandName: savedBranding.brandName || '',
+      brandColor: savedBranding.brandColor || '#895af6'
     }));
   }, []);
 
@@ -65,6 +72,7 @@ const Profile = () => {
       messageLink: formData.messageLink,
       meetingLink: formData.meetingLink
     }));
+    saveBranding({ brandName: formData.brandName, brandColor: formData.brandColor });
     toast({
       title: "Profil mis à jour",
       description: "Vos modifications ont été enregistrées avec succès."
@@ -244,11 +252,45 @@ const Profile = () => {
                 disabled={!isEditing}
               />
             </div>
+        </CardContent>
+      </Card>
+
+      {/* Branding Premium */}
+      {userPlan?.plan_type === 'pro' && (
+        <Card>
+          <CardHeader>
+            <div className="flex items-center gap-2">
+              <Palette className="w-5 h-5" />
+              <CardTitle>Branding</CardTitle>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="brandName">Nom de l'entreprise</Label>
+              <Input
+                id="brandName"
+                value={formData.brandName}
+                onChange={(e) => setFormData(prev => ({ ...prev, brandName: e.target.value }))}
+                disabled={!isEditing}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="brandColor">Couleur principale</Label>
+              <Input
+                id="brandColor"
+                type="color"
+                value={formData.brandColor}
+                onChange={(e) => setFormData(prev => ({ ...prev, brandColor: e.target.value }))}
+                disabled={!isEditing}
+                className="w-16 h-10 p-1"
+              />
+            </div>
           </CardContent>
         </Card>
+      )}
 
-        {/* Préférences */}
-        <Card>
+      {/* Préférences */}
+      <Card>
             <CardHeader>
               <div className="flex items-center gap-2">
                 <Settings className="w-5 h-5" />


### PR DESCRIPTION
## Summary
- allow pro users to configure portal name and color in profile
- load branding settings in client portal components
- provide branding utility helpers

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4f5d39a8832db85d7d2771e2eaa5