### PR TITLE
Adapt "Découvrir" links to workspace branding

### DIFF
--- a/src/components/layout/ClientNavigation.tsx
+++ b/src/components/layout/ClientNavigation.tsx
@@ -18,6 +18,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
   const [mobileOpen, setMobileOpen] = useState(false);
   const [isDark, setIsDark] = useState(false);
   const branding = loadBranding();
+  const brandLabel = branding.brandName?.trim() || 'Lumina';
 
   useEffect(() => {
     applyBranding(branding);
@@ -44,7 +45,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
           </div>
           {(!collapsed || isMobile) && (
             <div>
-              <h1 className="text-xl font-bold bg-gradient-primary bg-clip-text text-transparent">{branding.brandName || 'Lumina'}</h1>
+              <h1 className="text-xl font-bold bg-gradient-primary bg-clip-text text-transparent">{brandLabel}</h1>
               <p className="text-sm text-muted-foreground">Espace Client</p>
             </div>
           )}
@@ -76,7 +77,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
             className={cn('w-full justify-start gap-3 text-muted-foreground', collapsed && !isMobile && 'justify-center px-2')}
           >
             <ExternalLink className="w-4 h-4" />
-            {(!collapsed || isMobile) && `Découvrir ${branding.brandName || 'Lumina'}`}
+            {(!collapsed || isMobile) && `Découvrir ${brandLabel}`}
           </Button>
 
           {/* Dark mode toggle */}
@@ -117,7 +118,7 @@ const ClientNavigation = ({ spaceName, spacePrice, onSidebarChange }: ClientNavi
               <Bot className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h1 className="text-lg font-bold bg-gradient-primary bg-clip-text text-transparent">{branding.brandName || 'Lumina'}</h1>
+              <h1 className="text-lg font-bold bg-gradient-primary bg-clip-text text-transparent">{brandLabel}</h1>
               {spaceName && (
                 <p className="text-xs text-muted-foreground truncate max-w-32">{spaceName}</p>
               )}

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -6,6 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Eye, EyeOff, Sparkles, Users, Target, Zap } from 'lucide-react';
+import { loadBranding } from '@/lib/branding';
 import { useAuth } from '@/contexts/AuthContext';
 
 const Auth = () => {
@@ -18,6 +19,8 @@ const Auth = () => {
     password: '',
     confirmPassword: ''
   });
+  const branding = loadBranding();
+  const brandLabel = branding.brandName?.trim() || 'Lumina';
 
   // Redirect if already authenticated
   useEffect(() => {
@@ -115,7 +118,7 @@ const Auth = () => {
             </p>
             <Link to="/" className="inline-flex items-center gap-2 text-primary hover:underline mt-2">
               <Sparkles className="w-4 h-4" />
-              Découvrir Lumina
+                {`Découvrir ${brandLabel}`}
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Show workspace brand on navigation "Découvrir" button with a Lumina fallback
- Mirror branding on Auth page "Découvrir" link

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb528a2430832da1a02f028d5d3f65