### PR TITLE
feat: add cold email sequence launcher

### DIFF
--- a/src/components/prospection/ColdEmailLauncher.tsx
+++ b/src/components/prospection/ColdEmailLauncher.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react';
+import { Mail } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+interface ColdEmailLauncherProps {
+  content: string;
+}
+
+const ColdEmailLauncher = ({ content }: ColdEmailLauncherProps) => {
+  const [webhookUrl, setWebhookUrl] = useState('');
+  const [recipients, setRecipients] = useState('');
+  const [sending, setSending] = useState(false);
+  const [status, setStatus] = useState('');
+
+  const handleSend = async () => {
+    setSending(true);
+    setStatus('Envoi en cours...');
+    try {
+      await fetch(webhookUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          recipients: recipients
+            .split(',')
+            .map((email) => email.trim())
+            .filter(Boolean),
+          content,
+        }),
+      });
+      setStatus('Séquence envoyée avec succès !');
+    } catch (err) {
+      setStatus("Erreur lors de l'envoi");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <Card className="glass-glow mt-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Mail className="w-5 h-5 text-green-500" />
+          Envoyer la séquence
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div>
+          <Label htmlFor="webhook">Webhook ActivePiece</Label>
+          <Input
+            id="webhook"
+            placeholder="https://example.com/webhook"
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="recipients">Destinataires (séparés par des virgules)</Label>
+          <Input
+            id="recipients"
+            placeholder="email1@example.com, email2@example.com"
+            value={recipients}
+            onChange={(e) => setRecipients(e.target.value)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="content">Contenu</Label>
+          <Textarea id="content" value={content} readOnly className="min-h-[200px]" />
+        </div>
+        <Button
+          onClick={handleSend}
+          disabled={sending || !webhookUrl || !recipients}
+          className="gap-2"
+        >
+          {sending ? 'Envoi...' : 'Envoyer'}
+        </Button>
+        {status && <p className="text-sm text-muted-foreground">{status}</p>}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default ColdEmailLauncher;
+

--- a/src/pages/Copyly.tsx
+++ b/src/pages/Copyly.tsx
@@ -9,6 +9,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import AssistantWidget from '@/components/assistants/AssistantWidget';
+import ColdEmailLauncher from '@/components/prospection/ColdEmailLauncher';
 
 const Copyly = () => {
   const { hasFeatureAccess, upgradeRequired, loading } = usePlan();
@@ -23,6 +24,7 @@ const Copyly = () => {
   }, [hasFeatureAccess, upgradeRequired, navigate, loading]);
   const [aiMessage, setAiMessage] = useState('');
   const [generatedContent, setGeneratedContent] = useState('');
+  const [generatedType, setGeneratedType] = useState<'social' | 'sales' | 'email' | ''>('');
   const [copied, setCopied] = useState(false);
   const [isGenerating, setIsGenerating] = useState(false);
 
@@ -46,6 +48,7 @@ const Copyly = () => {
 
   const handleSocialGeneration = async () => {
     setIsGenerating(true);
+    setGeneratedType('social');
     setAiMessage('🦉 Je réfléchis à du contenu engageant...');
     
     // Simulation génération IA
@@ -72,6 +75,7 @@ Prêt(e) à passer au niveau supérieur ?
 
   const handleSalesGeneration = async () => {
     setIsGenerating(true);
+    setGeneratedType('sales');
     setAiMessage('🦉 Création d\'une page de vente persuasive...');
     
     setTimeout(() => {
@@ -110,6 +114,7 @@ Vous perdez du temps et de l'énergie avec des solutions inadaptées...
 
   const handleEmailGeneration = async () => {
     setIsGenerating(true);
+    setGeneratedType('email');
     setAiMessage('🦉 Rédaction d\'une séquence email captivante...');
     
     setTimeout(() => {
@@ -336,29 +341,34 @@ C'est votre dernière chance de...
           </Tabs>
 
           {generatedContent && (
-            <Card className="glass-glow mt-6">
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <CardTitle>Contenu généré</CardTitle>
-                  <Button 
-                    size="sm" 
-                    variant="outline"
-                    onClick={copyToClipboard}
-                    className="gap-2"
-                  >
-                    {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
-                    {copied ? 'Copié !' : 'Copier'}
-                  </Button>
-                </div>
-              </CardHeader>
-              <CardContent>
-                <Textarea 
-                  value={generatedContent} 
-                  readOnly
-                  className="min-h-[300px] font-mono text-sm"
-                />
-              </CardContent>
-            </Card>
+            <>
+              <Card className="glass-glow mt-6">
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <CardTitle>Contenu généré</CardTitle>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={copyToClipboard}
+                      className="gap-2"
+                    >
+                      {copied ? <Check className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+                      {copied ? 'Copié !' : 'Copier'}
+                    </Button>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <Textarea
+                    value={generatedContent}
+                    readOnly
+                    className="min-h-[300px] font-mono text-sm"
+                  />
+                </CardContent>
+              </Card>
+              {generatedType === 'email' && (
+                <ColdEmailLauncher content={generatedContent} />
+              )}
+            </>
           )}
         </div>
 


### PR DESCRIPTION
## Summary
- add ColdEmailLauncher component to send sequences via webhook
- integrate email sequence launcher into Copyly page

## Testing
- `npm run lint` *(fails: Unexpected any and other errors in unrelated files)*
- `npx eslint src/components/prospection/ColdEmailLauncher.tsx src/pages/Copyly.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68bb5992ac90832d85ce298c287dba15