### PR TITLE
refactor: redesign Copyly content generator

### DIFF
--- a/src/pages/Copyly.tsx
+++ b/src/pages/Copyly.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Edit3, Instagram, Mail, Globe, Wand2, Copy, Check } from 'lucide-react';
+import { Instagram, Mail, Globe, Wand2, Copy, Check } from 'lucide-react';
 import { usePlan } from '@/contexts/PlanContext';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
@@ -8,7 +8,6 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import AssistantWidget from '@/components/assistants/AssistantWidget';
 
 const Copyly = () => {
   const { hasFeatureAccess, upgradeRequired, loading } = usePlan();
@@ -35,13 +34,15 @@ const Copyly = () => {
   const [salesForm, setSalesForm] = useState({
     product: '',
     target: '',
-    benefit: ''
+    benefit: '',
+    price: ''
   });
 
   const [emailForm, setEmailForm] = useState({
     subject: '',
     goal: '',
-    audience: ''
+    audience: '',
+    tone: 'professionnel'
   });
 
   const handleSocialGeneration = async () => {
@@ -50,22 +51,10 @@ const Copyly = () => {
     
     // Simulation génération IA
     setTimeout(() => {
-      const content = `🚀 ${socialForm.topic} : L'innovation au service de votre réussite !
+      const content = `${socialForm.platform.toUpperCase()} - Ton ${socialForm.tone}\n\n🚀 ${socialForm.topic} : L'innovation au service de votre réussite !\n\n✨ Découvrez comment transformer vos idées en réalité avec nos solutions sur-mesure.\n\n💡 3 raisons de nous faire confiance :\n• Expertise technique reconnue\n• Accompagnement personnalisé\n• Résultats mesurables\n\nPrêt(e) à passer au niveau supérieur ?\n👉 DM pour en discuter !\n\n#innovation #digital #transformation #${socialForm.topic.toLowerCase()}`;
 
-✨ Découvrez comment transformer vos idées en réalité avec nos solutions sur-mesure.
-
-💡 3 raisons de nous faire confiance :
-• Expertise technique reconnue
-• Accompagnement personnalisé  
-• Résultats mesurables
-
-Prêt(e) à passer au niveau supérieur ? 
-👉 DM pour en discuter !
-
-#innovation #digital #transformation #${socialForm.topic.toLowerCase()}`;
-      
       setGeneratedContent(content);
-      setAiMessage('✅ Caption créée ! Optimisée pour l\'engagement et la conversion.');
+      setAiMessage(`✅ Caption ${socialForm.platform} générée en style ${socialForm.tone}.`);
       setIsGenerating(false);
     }, 2000);
   };
@@ -75,33 +64,8 @@ Prêt(e) à passer au niveau supérieur ?
     setAiMessage('🦉 Création d\'une page de vente persuasive...');
     
     setTimeout(() => {
-      const content = `# Transformez votre ${salesForm.product} en Succès Garanti !
+      const content = `# Transformez votre ${salesForm.product} en Succès Garanti !\n\n## 🎯 Pour ${salesForm.target} qui veulent ${salesForm.benefit}\n\n### Le Problème\nVous perdez du temps et de l'énergie avec des solutions inadaptées...\n\n### Notre Solution\n**${salesForm.product}** - La solution tout-en-un qui va révolutionner votre approche !\n\n### Les Bénéfices\n✅ ${salesForm.benefit} en quelques clics\n✅ Gain de temps immédiat\n✅ Résultats mesurables dès J+1\n✅ Support expert inclus\n\n### Témoignages\n"Grâce à cette solution, j'ai économisé 10h/semaine !" - Client satisfait\n\n### Offre Limitée\n🔥 **Prix spécial: ${salesForm.price || '99€'}**\n⏰ Plus que quelques places disponibles\n\n[**COMMANDER MAINTENANT**]\n\n*Garantie 30 jours satisfait ou remboursé*`;
 
-## 🎯 Pour ${salesForm.target} qui veulent ${salesForm.benefit}
-
-### Le Problème
-Vous perdez du temps et de l'énergie avec des solutions inadaptées...
-
-### Notre Solution
-**${salesForm.product}** - La solution tout-en-un qui va révolutionner votre approche !
-
-### Les Bénéfices
-✅ ${salesForm.benefit} en quelques clics
-✅ Gain de temps immédiat 
-✅ Résultats mesurables dès J+1
-✅ Support expert inclus
-
-### Témoignages
-"Grâce à cette solution, j'ai économisé 10h/semaine !" - Client satisfait
-
-### Offre Limitée
-🔥 **-50% pendant 48h** (au lieu de 199€)
-⏰ Plus que quelques places disponibles
-
-[**COMMANDER MAINTENANT - 99€**]
-
-*Garantie 30 jours satisfait ou remboursé*`;
-      
       setGeneratedContent(content);
       setAiMessage('🎯 Page de vente créée ! Optimisée pour la conversion avec techniques de persuasion.');
       setIsGenerating(false);
@@ -113,7 +77,7 @@ Vous perdez du temps et de l'énergie avec des solutions inadaptées...
     setAiMessage('🦉 Rédaction d\'une séquence email captivante...');
     
     setTimeout(() => {
-      const content = `**Email 1 - Ouverture** 📧
+      const content = `**Email 1 - Ouverture (${emailForm.tone})** 📧
 Objet: ${emailForm.subject}
 
 Bonjour [Prénom],
@@ -127,7 +91,7 @@ Cordialement,
 
 ---
 
-**Email 2 - Relance** 📨
+**Email 2 - Relance (${emailForm.tone})** 📨
 Objet: Re: ${emailForm.subject} - Information importante
 
 Bonjour [Prénom],
@@ -138,7 +102,7 @@ Je reviens vers vous suite à mon email précédent...
 
 ---
 
-**Email 3 - Dernière chance** ⚡
+**Email 3 - Dernière chance (${emailForm.tone})** ⚡
 Objet: [URGENT] ${emailForm.subject} - Dernière chance
 
 Bonjour [Prénom],
@@ -148,7 +112,7 @@ C'est votre dernière chance de...
 [Call-to-action final]`;
       
       setGeneratedContent(content);
-      setAiMessage('📧 Séquence email complète ! 3 emails optimisés pour maximiser vos conversions.');
+      setAiMessage(`📧 Séquence email en style ${emailForm.tone} générée !`);
       setIsGenerating(false);
     }, 3000);
   };
@@ -162,7 +126,7 @@ C'est votre dernière chance de...
   return (
     <div className="flex h-screen bg-background overflow-hidden">
       <div className="flex-1 overflow-auto p-8">
-        <div className="space-y-6 fade-in">
+        <div className="space-y-6 fade-in max-w-5xl mx-auto">
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-3xl font-bold flex items-center gap-3">
@@ -175,8 +139,12 @@ C'est votre dernière chance de...
             </div>
           </div>
 
-      <div className="flex gap-6">
-        <div className="flex-1">
+          {aiMessage && (
+            <div className="rounded-md bg-muted p-4 text-sm" data-testid="ai-message">
+              {aiMessage}
+            </div>
+          )}
+
           <Tabs defaultValue="social" className="space-y-6">
             <TabsList className="grid w-full grid-cols-3">
               <TabsTrigger value="social" className="gap-2">
@@ -202,22 +170,22 @@ C'est votre dernière chance de...
                   </CardTitle>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-3 gap-4">
                     <div>
                       <Label htmlFor="topic">Sujet / Thème</Label>
                       <Input
                         id="topic"
                         value={socialForm.topic}
-                        onChange={(e) => setSocialForm({...socialForm, topic: e.target.value})}
+                        onChange={(e) => setSocialForm({ ...socialForm, topic: e.target.value })}
                         placeholder="Ex: Innovation digitale"
                       />
                     </div>
                     <div>
                       <Label htmlFor="platform">Plateforme</Label>
-                      <select 
+                      <select
                         className="w-full p-2 border rounded-md bg-background"
                         value={socialForm.platform}
-                        onChange={(e) => setSocialForm({...socialForm, platform: e.target.value})}
+                        onChange={(e) => setSocialForm({ ...socialForm, platform: e.target.value })}
                       >
                         <option value="instagram">Instagram</option>
                         <option value="linkedin">LinkedIn</option>
@@ -225,8 +193,21 @@ C'est votre dernière chance de...
                         <option value="facebook">Facebook</option>
                       </select>
                     </div>
+                    <div>
+                      <Label htmlFor="tone">Ton</Label>
+                      <select
+                        id="tone"
+                        className="w-full p-2 border rounded-md bg-background"
+                        value={socialForm.tone}
+                        onChange={(e) => setSocialForm({ ...socialForm, tone: e.target.value })}
+                      >
+                        <option value="professionnel">Professionnel</option>
+                        <option value="amical">Amical</option>
+                        <option value="humoristique">Humoristique</option>
+                      </select>
+                    </div>
                   </div>
-                  <Button 
+                  <Button
                     onClick={handleSocialGeneration}
                     disabled={isGenerating || !socialForm.topic}
                     className="gap-2"
@@ -274,7 +255,16 @@ C'est votre dernière chance de...
                       placeholder="Ex: Doubler leur chiffre d'affaires"
                     />
                   </div>
-                  <Button 
+                  <div>
+                    <Label htmlFor="price">Prix</Label>
+                    <Input
+                      id="price"
+                      value={salesForm.price}
+                      onChange={(e) => setSalesForm({ ...salesForm, price: e.target.value })}
+                      placeholder="Ex: 99€"
+                    />
+                  </div>
+                  <Button
                     onClick={handleSalesGeneration}
                     disabled={isGenerating || !salesForm.product}
                     className="gap-2"
@@ -303,6 +293,19 @@ C'est votre dernière chance de...
                       onChange={(e) => setEmailForm({...emailForm, subject: e.target.value})}
                       placeholder="Ex: Votre projet digital"
                     />
+                  </div>
+                  <div>
+                    <Label htmlFor="toneEmail">Ton</Label>
+                    <select
+                      id="toneEmail"
+                      className="w-full p-2 border rounded-md bg-background"
+                      value={emailForm.tone}
+                      onChange={(e) => setEmailForm({ ...emailForm, tone: e.target.value })}
+                    >
+                      <option value="professionnel">Professionnel</option>
+                      <option value="amical">Amical</option>
+                      <option value="humoristique">Humoristique</option>
+                    </select>
                   </div>
                   <div>
                     <Label htmlFor="goal">Objectif</Label>
@@ -340,8 +343,8 @@ C'est votre dernière chance de...
               <CardHeader>
                 <div className="flex items-center justify-between">
                   <CardTitle>Contenu généré</CardTitle>
-                  <Button 
-                    size="sm" 
+                  <Button
+                    size="sm"
                     variant="outline"
                     onClick={copyToClipboard}
                     className="gap-2"
@@ -352,27 +355,14 @@ C'est votre dernière chance de...
                 </div>
               </CardHeader>
               <CardContent>
-                <Textarea 
-                  value={generatedContent} 
+                <Textarea
+                  value={generatedContent}
                   readOnly
-                  className="min-h-[300px] font-mono text-sm"
+                  className="min-h-[400px] font-mono text-sm"
                 />
               </CardContent>
             </Card>
           )}
-        </div>
-
-        <div className="w-80">
-          <AssistantWidget
-            name="Copyly"
-            description="Générateur de contenu"
-            color="purple"
-            avatar="🦉"
-            message={aiMessage || "Hoot hoot ! 🦉 Prêt à créer du contenu qui convertit ? Remplis les champs et je vais te concocter du contenu marketing de qualité professionnelle !"}
-            className="sticky top-6"
-          />
-        </div>
-      </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove assistant chat widget and adopt Pipou-style layout with full-width generator
- expand content forms with tone and price options and larger output area

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 134 errors, 16 warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb634a19fc832d9708f59213c2a5d4