### PR TITLE
feat: create client space from prospect cards

### DIFF
--- a/src/components/prospection/ProspectCreateSpaceDialog.tsx
+++ b/src/components/prospection/ProspectCreateSpaceDialog.tsx
@@ -1,0 +1,123 @@
+import { useState, useEffect } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Prospect } from '@/types/prospect';
+import nocodbService from '@/services/nocodbService';
+import { useToast } from '@/hooks/use-toast';
+
+interface ProspectCreateSpaceDialogProps {
+  prospect: Prospect | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated?: () => void;
+}
+
+const ProspectCreateSpaceDialog = ({ prospect, open, onOpenChange, onCreated }: ProspectCreateSpaceDialogProps) => {
+  const { toast } = useToast();
+  const [form, setForm] = useState({
+    email: '',
+    description: '',
+    statut: 'Nouveau',
+  });
+
+  useEffect(() => {
+    if (prospect) {
+      setForm({
+        email: prospect.email || '',
+        description: prospect.company || prospect.name || '',
+        statut: 'Nouveau',
+      });
+    }
+  }, [prospect]);
+
+  const handleChange = (field: keyof typeof form) => (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    setForm({ ...form, [field]: e.target.value });
+  };
+
+  const handleCreate = async () => {
+    if (!form.email.trim()) return;
+    try {
+      const payload = {
+        email: form.email.trim(),
+        statut: form.statut,
+        description: form.description.trim() || null,
+        lien_portail: null,
+        prix_payement: null,
+        lien_payement: null,
+        lien_whatsapp: null,
+        cz787nu83e9bvlu: null,
+        client_access_enabled: false,
+        client_link_token: null,
+        notes: JSON.stringify({
+          created_by: 'admin',
+          creation_date: new Date().toISOString(),
+        }),
+      };
+      await nocodbService.createClient(payload);
+      toast({ title: 'Espace créé', description: "L'espace client a été créé avec succès" });
+      onOpenChange(false);
+      onCreated?.();
+    } catch (error) {
+      console.error('Erreur création espace:', error);
+      toast({ title: 'Erreur', description: "Impossible de créer l'espace client", variant: 'destructive' });
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Créer un espace</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="space-email">Email du client *</Label>
+            <Input
+              id="space-email"
+              type="email"
+              value={form.email}
+              onChange={handleChange('email')}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="space-description">Description du projet</Label>
+            <Textarea
+              id="space-description"
+              value={form.description}
+              onChange={handleChange('description')}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Statut</Label>
+            <Select value={form.statut} onValueChange={value => setForm({ ...form, statut: value })}>
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Nouveau">Nouveau</SelectItem>
+                <SelectItem value="En cours">En cours</SelectItem>
+                <SelectItem value="Terminé">Terminé</SelectItem>
+                <SelectItem value="En attente">En attente</SelectItem>
+                <SelectItem value="Annulé">Annulé</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </div>
+        <div className="flex justify-end gap-3">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Annuler
+          </Button>
+          <Button onClick={handleCreate} disabled={!form.email.trim()}>
+            Créer
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProspectCreateSpaceDialog;

--- a/src/components/prospection/ProspectKanban.tsx
+++ b/src/components/prospection/ProspectKanban.tsx
@@ -5,13 +5,12 @@ import { mapProspectStatusToNoco } from '@/lib/prospectStatus';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Mail, Phone, Edit, Trash2, Globe, Calendar } from 'lucide-react';
+import { Mail, Phone, Globe, Calendar } from 'lucide-react';
 
 interface ProspectKanbanProps {
   prospects: Prospect[];
   setProspects: React.Dispatch<React.SetStateAction<Prospect[]>>;
-  onEdit: (prospect: Prospect) => void;
-  onDelete: (id: string) => void;
+  onCreateSpace: (prospect: Prospect) => void;
 }
 
 const statuses = [
@@ -22,7 +21,7 @@ const statuses = [
   { id: 'Converti', title: 'Converti', color: 'bg-green-100 dark:bg-green-900/30' },
 ];
 
-const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects, onEdit, onDelete }) => {
+const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects, onCreateSpace }) => {
   const handleDragStart = (event: React.DragEvent<HTMLDivElement>, id: string) => {
     event.dataTransfer.setData('text/plain', id);
   };
@@ -71,32 +70,32 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
                   onDragStart={e => handleDragStart(e, p.id)}
                 >
                   <CardContent className="p-4 space-y-3">
-                    <div className="flex justify-between items-start">
+                    <div className="flex items-start">
                       <div className="flex-1">
-                        <h4 className="font-medium">{p.name}</h4>
+                        <h4 className="font-medium break-words">{p.name}</h4>
                         {p.company && (
-                          <p className="text-sm text-muted-foreground">{p.company}</p>
+                          <p className="text-sm text-muted-foreground break-words">{p.company}</p>
                         )}
                         {p.email && (
-                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
+                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1 break-all">
                             <Mail className="w-3 h-3" />
                             {p.email}
                           </p>
                         )}
                         {p.phone && (
-                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
+                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1 break-all">
                             <Phone className="w-3 h-3" />
                             {p.phone}
                           </p>
                         )}
                         {p.website && (
-                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
+                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1 break-all">
                             <Globe className="w-3 h-3" />
                             <a
                               href={ensureProtocol(p.website)}
                               target="_blank"
                               rel="noopener noreferrer"
-                              className="underline underline-offset-2 hover:no-underline"
+                              className="underline underline-offset-2 hover:no-underline break-all"
                               onClick={e => e.stopPropagation()}
                             >
                               {p.website}
@@ -104,62 +103,33 @@ const ProspectKanban: React.FC<ProspectKanbanProps> = ({ prospects, setProspects
                           </p>
                         )}
                         {p.lastContact && (
-                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1">
+                          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-1 break-words">
                             <Calendar className="w-3 h-3" />
                             Dernier contact: {new Date(p.lastContact).toLocaleDateString()}
                           </p>
                         )}
                       </div>
-                      <div className="flex gap-1" onClick={e => e.stopPropagation()}>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={e => {
-                            e.stopPropagation();
-                            onEdit(p);
-                          }}
-                        >
-                          <Edit className="w-4 h-4" />
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={e => {
-                            e.stopPropagation();
-                            onDelete(p.id);
-                          }}
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </Button>
-                      </div>
                     </div>
 
-                    {(p.email || p.phone || p.website) && (
+                    {(p.email || p.phone) && (
                       <div className="flex gap-2 pt-2 flex-wrap" onClick={e => e.stopPropagation()}>
-                        {p.email && (
-                          <Button size="sm" className="gap-2" asChild>
-                            <a href={`mailto:${p.email}`}>
-                              <Mail className="w-4 h-4" />
-                              Email
-                            </a>
-                          </Button>
-                        )}
-                        {p.phone && (
-                          <Button size="sm" variant="secondary" className="gap-2" asChild>
-                            <a href={`tel:${p.phone}`}>
-                              <Phone className="w-4 h-4" />
-                              Appeler
-                            </a>
-                          </Button>
-                        )}
-                        {p.website && (
-                          <Button size="sm" variant="outline" className="gap-2" asChild>
-                            <a href={ensureProtocol(p.website)} target="_blank" rel="noopener noreferrer">
-                              <Globe className="w-4 h-4" />
-                              Site
-                            </a>
-                          </Button>
-                        )}
+                        <Button size="sm" className="gap-2" asChild>
+                          <a href={p.email ? `mailto:${p.email}` : `tel:${p.phone}`}>
+                            {p.email ? <Mail className="w-4 h-4" /> : <Phone className="w-4 h-4" />}
+                            Contacter
+                          </a>
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          className="gap-2"
+                          onClick={e => {
+                            e.stopPropagation();
+                            onCreateSpace(p);
+                          }}
+                        >
+                          Créer un espace
+                        </Button>
                       </div>
                     )}
                   </CardContent>

--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -14,6 +14,7 @@ import { Prospect } from '@/types/prospect';
 import { mapProspectStatus, mapProspectStatusToNoco } from '@/lib/prospectStatus';
 import MilestoneManager from '@/components/milestones/MilestoneManager';
 import NocoInvoiceManager from '@/components/invoices/NocoInvoiceManager';
+import ProspectCreateSpaceDialog from '@/components/prospection/ProspectCreateSpaceDialog';
 
 type NocoRecord = Record<string, unknown>;
 
@@ -110,6 +111,7 @@ const Pipou = () => {
   const [isEditProspectDialogOpen, setIsEditProspectDialogOpen] = useState(false);
   const [editingProspect, setEditingProspect] = useState<Prospect | null>(null);
   const [activeTab, setActiveTab] = useState('clients');
+  const [spaceProspect, setSpaceProspect] = useState<Prospect | null>(null);
 
   const buildProspectPayload = (
     data: ProspectFormData & { status: string; lastContact?: string }
@@ -514,15 +516,7 @@ const Pipou = () => {
               <ProspectKanban
                 prospects={prospects}
                 setProspects={setProspects}
-                onEdit={(prospect) => {
-                  setEditingProspect(prospect);
-                  setIsEditProspectDialogOpen(true);
-                }}
-                onDelete={(id) => {
-                  if (confirm('Supprimer ce prospect ?')) {
-                    handleDeleteProspect(id);
-                  }
-                }}
+                onCreateSpace={(prospect) => setSpaceProspect(prospect)}
               />
               {hasMoreProspects && (
                 <div className="flex justify-center mt-4">
@@ -567,6 +561,16 @@ const Pipou = () => {
             />
           </DialogContent>
         </Dialog>
+      )}
+      {spaceProspect && (
+        <ProspectCreateSpaceDialog
+          prospect={spaceProspect}
+          open={true}
+          onOpenChange={open => {
+            if (!open) setSpaceProspect(null);
+          }}
+          onCreated={() => setSpaceProspect(null)}
+        />
       )}
       {selectedProject && (
         <ClientShareDialog


### PR DESCRIPTION
## Summary
- prevent overflow and simplify actions in prospect kanban cards
- add dialog prefilled from prospect to create client spaces

## Testing
- `npm run lint` *(fails: Unexpected any in other files)*
- `npx eslint src/components/prospection/ProspectKanban.tsx src/components/prospection/ProspectCreateSpaceDialog.tsx src/pages/Pipou.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c0937d2ac4832d8863c9858776fc3a