### PR TITLE
Ensure current-user filtering and empty list messages

### DIFF
--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -441,74 +441,80 @@ const Pipou = () => {
                     </TabsList>
 
                     <TabsContent value="list" className="grid gap-4">
-                      {prospects.map((prospect) => (
-                        <Card key={prospect.id} className="glass-glow hover:shadow-glow transition-all duration-300">
-                          <CardHeader>
-                            <div className="flex items-start justify-between">
-                              <div>
-                                <CardTitle className="text-lg">{prospect.name}</CardTitle>
+                      {prospects.length === 0 ? (
+                        <p className="text-center text-sm text-muted-foreground">
+                          Aucun prospect trouvé.
+                        </p>
+                      ) : (
+                        prospects.map((prospect) => (
+                          <Card key={prospect.id} className="glass-glow hover:shadow-glow transition-all duration-300">
+                            <CardHeader>
+                              <div className="flex items-start justify-between">
+                                <div>
+                                  <CardTitle className="text-lg">{prospect.name}</CardTitle>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                  {prospect.status && (
+                                    <span className="text-sm text-muted-foreground">
+                                      {prospect.status}
+                                    </span>
+                                  )}
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => {
+                                      setEditingProspect(prospect);
+                                      setIsEditProspectDialogOpen(true);
+                                    }}
+                                  >
+                                    <Edit className="w-4 h-4" />
+                                  </Button>
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    onClick={() => {
+                                      if (confirm('Supprimer ce prospect ?')) {
+                                        handleDeleteProspect(prospect.id);
+                                      }
+                                    }}
+                                  >
+                                    <Trash2 className="w-4 h-4" />
+                                  </Button>
+                                </div>
+                            </div>
+                          </CardHeader>
+                          <CardContent className="space-y-4 text-sm">
+                              <div className="flex justify-between">
+                                <span>Email</span>
+                                <span className="font-medium">{prospect.email}</span>
                               </div>
-                              <div className="flex items-center gap-2">
-                                {prospect.status && (
-                                  <span className="text-sm text-muted-foreground">
-                                    {prospect.status}
-                                  </span>
+                              <div className="flex justify-between">
+                                <span>Téléphone</span>
+                                <span className="font-medium">{prospect.phone}</span>
+                              </div>
+                              <div className="flex gap-2 pt-2 flex-wrap">
+                                {prospect.email && (
+                                  <Button size="sm" className="gap-2" asChild>
+                                    <a href={`mailto:${prospect.email}`}>
+                                      <Mail className="w-4 h-4" />
+                                      Contacter
+                                    </a>
+                                  </Button>
                                 )}
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  onClick={() => {
-                                    setEditingProspect(prospect);
-                                    setIsEditProspectDialogOpen(true);
-                                  }}
-                                >
-                                  <Edit className="w-4 h-4" />
-                                </Button>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  onClick={() => {
-                                    if (confirm('Supprimer ce prospect ?')) {
-                                      handleDeleteProspect(prospect.id);
-                                    }
-                                  }}
-                                >
-                                  <Trash2 className="w-4 h-4" />
-                                </Button>
+                                {prospect.phone && (
+                                  <Button size="sm" variant="secondary" className="gap-2" asChild>
+                                    <a href={`tel:${prospect.phone}`}>
+                                      <Phone className="w-4 h-4" />
+                                      Appeler
+                                    </a>
+                                  </Button>
+                                )}
                               </div>
-                          </div>
-                        </CardHeader>
-                        <CardContent className="space-y-4 text-sm">
-                            <div className="flex justify-between">
-                              <span>Email</span>
-                              <span className="font-medium">{prospect.email}</span>
-                            </div>
-                            <div className="flex justify-between">
-                              <span>Téléphone</span>
-                              <span className="font-medium">{prospect.phone}</span>
-                            </div>
-                            <div className="flex gap-2 pt-2 flex-wrap">
-                              {prospect.email && (
-                                <Button size="sm" className="gap-2" asChild>
-                                  <a href={`mailto:${prospect.email}`}>
-                                    <Mail className="w-4 h-4" />
-                                    Contacter
-                                  </a>
-                                </Button>
-                              )}
-                              {prospect.phone && (
-                                <Button size="sm" variant="secondary" className="gap-2" asChild>
-                                  <a href={`tel:${prospect.phone}`}>
-                                    <Phone className="w-4 h-4" />
-                                    Appeler
-                                  </a>
-                                </Button>
-                              )}
-                            </div>
 
-                          </CardContent>
-                        </Card>
-                      ))}
+                            </CardContent>
+                          </Card>
+                        ))
+                      )}
                       {hasMoreProspects && (
                         <div className="flex justify-center">
                           <Button onClick={loadProspects} disabled={isLoadingProspects}>
@@ -519,17 +525,25 @@ const Pipou = () => {
                     </TabsContent>
 
             <TabsContent value="kanban">
-              <ProspectKanban
-                prospects={prospects}
-                setProspects={setProspects}
-                onCreateSpace={(prospect) => setSpaceProspect(prospect)}
-              />
-              {hasMoreProspects && (
-                <div className="flex justify-center mt-4">
-                  <Button onClick={loadProspects} disabled={isLoadingProspects}>
-                    {isLoadingProspects ? 'Chargement...' : 'Charger plus'}
-                  </Button>
-                </div>
+              {prospects.length === 0 ? (
+                <p className="text-center text-sm text-muted-foreground">
+                  Aucun prospect trouvé.
+                </p>
+              ) : (
+                <>
+                  <ProspectKanban
+                    prospects={prospects}
+                    setProspects={setProspects}
+                    onCreateSpace={(prospect) => setSpaceProspect(prospect)}
+                  />
+                  {hasMoreProspects && (
+                    <div className="flex justify-center mt-4">
+                      <Button onClick={loadProspects} disabled={isLoadingProspects}>
+                        {isLoadingProspects ? 'Chargement...' : 'Charger plus'}
+                      </Button>
+                    </div>
+                  )}
+                </>
               )}
             </TabsContent>
           </Tabs>

--- a/src/pages/Tasky.tsx
+++ b/src/pages/Tasky.tsx
@@ -478,13 +478,18 @@ const Tasky = () => {
         )}
         {viewMode === 'kanban' ? (
           <div className="grid grid-cols-1 md:grid-cols-4 gap-6 w-full">
-              {columns.map((column) => (
+            {tasks.length === 0 ? (
+              <p className="col-span-full text-center text-sm text-muted-foreground">
+                Aucune tâche trouvée.
+              </p>
+            ) : (
+              columns.map((column) => (
                 <div
-                key={column.id}
-                className={`${column.color} rounded-lg p-4`}
-                onDragOver={handleDragOver}
-                onDrop={e => handleDrop(e, column.id)}
-              >
+                  key={column.id}
+                  className={`${column.color} rounded-lg p-4`}
+                  onDragOver={handleDragOver}
+                  onDrop={e => handleDrop(e, column.id)}
+                >
                   <h3 className="font-semibold mb-4 flex items-center justify-between">
                     {column.title}
                     <Badge variant="secondary" className="ml-2">
@@ -560,8 +565,9 @@ const Tasky = () => {
                       ))}
                   </div>
                 </div>
-              ))}
-        </div>
+              ))
+            )}
+          </div>
       ) : (
         <Card className="glass-glow">
               <CardHeader>
@@ -569,59 +575,65 @@ const Tasky = () => {
               </CardHeader>
               <CardContent>
                 <div className="space-y-3">
-                  {tasks.map((task) => (
-                    <div key={task.id} className="space-y-2">
-                      <div
-                        className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent/50 transition-colors"
-                      >
-                        <div>
-                          <h4 className="font-medium">{task.titre}</h4>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          {!task.isInternal && task._spaceName && (
-                            <Badge variant="outline">{task._spaceName}</Badge>
-                          )}
-                          {!task.isInternal && (
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => setTimerTaskId(timerTaskId === task.id ? null : task.id)}
-                              className="gap-2"
-                            >
-                              <Clock className="w-4 h-4" />
-                              Timer
-                            </Button>
-                          )}
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              onClick={() => handleTaskDeconstruct(task)}
-                              disabled={isClientTask(task)}
-                            >
-                              Déconstruire la tâche
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              onClick={() => handleEditTask(task)}
-                              className="p-2"
-                            >
-                              <Edit className="w-4 h-4" />
-                              <span className="sr-only">Editer</span>
-                            </Button>
-                            <Button
-                              size="sm"
-                              variant="ghost"
-                              onClick={() => handleDeleteTask(task)}
-                              className="p-2 text-destructive"
-                            >
-                              <Trash2 className="w-4 h-4" />
-                              <span className="sr-only">Supprimer</span>
-                            </Button>
+                  {tasks.length === 0 ? (
+                    <p className="text-center text-sm text-muted-foreground">
+                      Aucune tâche trouvée.
+                    </p>
+                  ) : (
+                    tasks.map((task) => (
+                      <div key={task.id} className="space-y-2">
+                        <div
+                          className="flex items-center justify-between p-4 border rounded-lg hover:bg-accent/50 transition-colors"
+                        >
+                          <div>
+                            <h4 className="font-medium">{task.titre}</h4>
+                          </div>
+                          <div className="flex items-center gap-3">
+                            {!task.isInternal && task._spaceName && (
+                              <Badge variant="outline">{task._spaceName}</Badge>
+                            )}
+                            {!task.isInternal && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => setTimerTaskId(timerTaskId === task.id ? null : task.id)}
+                                className="gap-2"
+                              >
+                                <Clock className="w-4 h-4" />
+                                Timer
+                              </Button>
+                            )}
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => handleTaskDeconstruct(task)}
+                                disabled={isClientTask(task)}
+                              >
+                                Déconstruire la tâche
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => handleEditTask(task)}
+                                className="p-2"
+                              >
+                                <Edit className="w-4 h-4" />
+                                <span className="sr-only">Editer</span>
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => handleDeleteTask(task)}
+                                className="p-2 text-destructive"
+                              >
+                                <Trash2 className="w-4 h-4" />
+                                <span className="sr-only">Supprimer</span>
+                              </Button>
+                          </div>
                         </div>
                       </div>
-                    </div>
-                  ))}
+                    ))
+                  )}
                   </div>
                 </CardContent>
           </Card>

--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -408,7 +408,6 @@ class NocoDBService {
           const prospectUserId =
             prospect.supabase_user_id ||
             prospect.user_id ||
-            prospect.userId ||
             prospect.owner_id;
           return prospectUserId === currentUserId;
         });
@@ -565,7 +564,6 @@ class NocoDBService {
           const taskUserId =
             task.supabase_user_id ||
             task.user_id ||
-            task.userId ||
             task.owner_id;
           return taskUserId === currentUserId;
         });
@@ -655,7 +653,6 @@ class NocoDBService {
           const taskUserId =
             task.supabase_user_id ||
             task.user_id ||
-            task.userId ||
             task.owner_id;
           return taskUserId === currentUserId;
         });


### PR DESCRIPTION
## Summary
- Simplify user-id filters in `getProspects` and `getInternalTasks`
- Always request current user's data and show empty-state messages in Tasky and Pipou

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c56a005168832d9d78fe20d4d14f92