### PR TITLE
Respect onlyCurrentUser when user has no project access

### DIFF
--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -537,8 +537,9 @@ class NocoDBService {
       .map((p: any) => (p.Id || p.id)?.toString())
       .filter(Boolean);
 
-    // If user has no accessible projects and no specific project requested, return empty
-    if (!projetId && userProjectIds.length === 0) {
+    // If user has no accessible projects and no specific project requested,
+    // return empty only when not filtering for the current user
+    if (!projetId && userProjectIds.length === 0 && !options.onlyCurrentUser) {
       return { list: [], pageInfo: { totalRows: 0 } };
     }
 


### PR DESCRIPTION
## Summary
- prevent getTasks from returning empty when fetching only current user's tasks with no project access

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: found 152 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c56dd3c840832d9a967678fcd16beb