### PR TITLE
feat: restrict global stats to current user

### DIFF
--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -42,7 +42,7 @@ export const useGlobalStats = () => {
         // Charger les données en parallèle pour accélérer l'affichage des statistiques
         // Récupérer uniquement les tâches de l'utilisateur courant
         const [tasksResponse, milestonesResponse, invoicesResponse] = await Promise.all([
-          nocodbService.getTasks(undefined, { onlyCurrentUser: false }),
+          nocodbService.getTasks(undefined, { onlyCurrentUser: true }),
           nocodbService.getMilestones(),
           nocodbService.getInvoices()
         ]);


### PR DESCRIPTION
## Summary
- ensure global statistics only fetch tasks for the current user by using `onlyCurrentUser`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: many `@typescript-eslint/no-explicit-any` errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c56dd4b920832d9a59fc328a4707ff