### PR TITLE
feat: backfill prospects for current user

### DIFF
--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -54,6 +54,18 @@ const Pipou = () => {
   const [milestonesProject, setMilestonesProject] = useState<Project | null>(null);
   const [invoicesProject, setInvoicesProject] = useState<Project | null>(null);
 
+  // Backfill des anciens prospects vers le compte courant
+  useEffect(() => {
+    const runBackfill = async () => {
+      try {
+        await nocodbService.backfillProspectsForCurrentUser();
+      } catch (e) {
+        console.warn('Backfill prospects échoué:', e);
+      }
+    };
+    runBackfill();
+  }, []);
+
   useEffect(() => {
     const loadProjects = async () => {
       try {


### PR DESCRIPTION
## Summary
- add `backfillProspectsForCurrentUser` to map existing prospects to logged-in user
- invoke prospect backfill when Pipou page loads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c56dd5b274832d8ac54fda027f8840