### PR TITLE
chore: backfill before filtered data

### DIFF
--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -35,8 +35,15 @@ export const useGlobalStats = () => {
   useEffect(() => {
     const loadGlobalStats = async () => {
       setStats(prev => ({ ...prev, isLoading: true }));
-      
+
       try {
+        // S'assurer que toutes les tâches de l'utilisateur courant sont correctement assignées
+        await nocodbService.backfillTasksForCurrentUser();
+        const anyService = nocodbService as any;
+        if (typeof anyService.backfillProspectsForCurrentUser === 'function') {
+          await anyService.backfillProspectsForCurrentUser();
+        }
+
         console.log('📊 Chargement des statistiques globales...');
         
         // Charger les données en parallèle pour accélérer l'affichage des statistiques

--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -135,6 +135,12 @@ const Pipou = () => {
   const loadProspects = useCallback(async () => {
     setIsLoadingProspects(true);
     try {
+      await nocodbService.backfillTasksForCurrentUser();
+      const anyService = nocodbService as any;
+      if (typeof anyService.backfillProspectsForCurrentUser === 'function') {
+        await anyService.backfillProspectsForCurrentUser();
+      }
+
       const response = await nocodbService.getProspects(
         PROSPECTS_PAGE_SIZE,
         prospectOffset,


### PR DESCRIPTION
## Summary
- ensure tasks backfill is complete before fetching global stats
- run user backfill before loading prospects and call future prospects backfill if available

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c56dd6c2d0832d9c98b56cb44241a3