### PR TITLE
feat: require user id for task creation

### DIFF
--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -610,11 +610,14 @@ class NocoDBService {
   }
 
   async createTask(data: any) {
-    const payload = { ...data };
     const userId = await this.getCurrentUserId();
-    if (userId) {
-      (payload as any).supabase_user_id = userId;
+    if (!userId) {
+      console.warn('User ID required to create task');
+      throw new Error('Missing user ID');
     }
+    const payload = { ...data };
+    (payload as any).supabase_user_id = userId;
+    (payload as any).c3bte4bwnnls4h = userId;
     const response = await this.makeRequest(`/${this.config.tableIds.taches}`, {
       method: 'POST',
       body: JSON.stringify(payload),


### PR DESCRIPTION
## Summary
- enforce authenticated user for NocoDB task creation
- store Supabase user id on task records

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `curl -i -X POST -H 'xc-token: PiPJbqfJYUrdeNA7n7hAsYt6fgLBFGRfcYFTRVdA' -H 'Content-Type: application/json' -d '{"supabase_user_id":"test","c3bte4bwnnls4h":"test"}' 'https://app.nocodb.com/api/v1/db/data/noco/pg5rbl36x41ud93/mon8rt3orldc3nc'` *(fails: 403 Forbidden)*
- `curl -i -H 'xc-token: PiPJbqfJYUrdeNA7n7hAsYt6fgLBFGRfcYFTRVdA' 'https://app.nocodb.com/api/v1/db/data/noco/pg5rbl36x41ud93/mon8rt3orldc3nc?where=(supabase_user_id,eq,test)'` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c572b7ba74832db2e551845d6f5c90