### PR TITLE
Remove duplicate prospect creation button

### DIFF
--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -343,11 +343,6 @@ const Pipou = () => {
               Prospection
             </TabsTrigger>
           </TabsList>
-          {activeTab === 'prospection' && (
-            <Button onClick={() => setIsCreateProspectDialogOpen(true)}>
-              Créer un prospect
-            </Button>
-          )}
         </div>
 
         <TabsContent value="clients" className="space-y-4">


### PR DESCRIPTION
## Summary
- Remove redundant "Créer un prospect" button from Pipou prospection header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 154 problems (137 errors, 17 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c576682f6c832d9992265cd3933575