### PR TITLE
Force refresh NocoDB data after backfill

### DIFF
--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -49,7 +49,7 @@ export const useGlobalStats = () => {
         // Charger les données en parallèle pour accélérer l'affichage des statistiques
         // Récupérer uniquement les tâches de l'utilisateur courant
         const [tasksResponse, milestonesResponse, invoicesResponse] = await Promise.all([
-          nocodbService.getTasks(undefined, { onlyCurrentUser: true }),
+          nocodbService.getTasks(undefined, { onlyCurrentUser: true }, true),
           nocodbService.getMilestones(),
           nocodbService.getInvoices()
         ]);

--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -153,12 +153,12 @@ const Pipou = () => {
         await anyService.backfillProspectsForCurrentUser();
       }
 
-      const response = await nocodbService.getProspects(
-        PROSPECTS_PAGE_SIZE,
-        prospectOffset,
-        false,
-        { onlyCurrentUser: true }
-      );
+        const response = await nocodbService.getProspects(
+          PROSPECTS_PAGE_SIZE,
+          prospectOffset,
+          true,
+          { onlyCurrentUser: true }
+        );
       const list = (response.list || []).map((p: Record<string, unknown>) => ({
         id: ((p as { Id?: unknown; id?: unknown }).Id || (p as { Id?: unknown; id?: unknown }).id || '').toString(),
         name: (p as { name?: string }).name || '',

--- a/src/pages/Tasky.tsx
+++ b/src/pages/Tasky.tsx
@@ -208,14 +208,22 @@ const Tasky = () => {
   useEffect(() => {
     const loadTasksFromNoco = async () => {
       try {
-        let list: any[] = [];
-        if (taskScope === 'internal') {
-          const res = await nocodbService.getInternalTasks({ onlyCurrentUser: true });
-          list = res.list || [];
-        } else {
-          const res = await nocodbService.getTasks(undefined, { onlyCurrentUser: true });
-          list = (res.list || []).map((t: any) => ({ ...t, isInternal: false }));
-        }
+          let list: any[] = [];
+          const forceRefresh = refreshTick > 0;
+          if (taskScope === 'internal') {
+            const res = await nocodbService.getInternalTasks(
+              { onlyCurrentUser: true },
+              forceRefresh
+            );
+            list = res.list || [];
+          } else {
+            const res = await nocodbService.getTasks(
+              undefined,
+              { onlyCurrentUser: true },
+              forceRefresh
+            );
+            list = (res.list || []).map((t: any) => ({ ...t, isInternal: false }));
+          }
 
         if (taskScope === 'client') {
 

--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -524,7 +524,8 @@ class NocoDBService {
   // Tâches - Filtered by user's projects
   async getTasks(
     projetId?: string,
-    options: { onlyCurrentUser?: boolean } = {}
+    options: { onlyCurrentUser?: boolean } = {},
+    forceRefresh = false
   ) {
     // Optionally filter by current Supabase user
     const currentUserId = options.onlyCurrentUser
@@ -547,7 +548,7 @@ class NocoDBService {
       ? `/${this.config.tableIds.taches}?where=(projet_id,eq,${projetId})`
       : `/${this.config.tableIds.taches}`;
 
-    const response = await this.makeRequest(endpoint);
+    const response = await this.makeRequest(endpoint, {}, 0, !forceRefresh);
     let list = response.list || [];
 
     if (projetId) {
@@ -644,13 +645,19 @@ class NocoDBService {
   }
 
   // Tâches internes
-  async getInternalTasks(options: { onlyCurrentUser?: boolean } = {}) {
+  async getInternalTasks(
+    options: { onlyCurrentUser?: boolean } = {},
+    forceRefresh = false
+  ) {
     const currentUserId = options.onlyCurrentUser
       ? await this.getCurrentUserId()
       : null;
 
     const response = await this.makeRequest(
-      `/${this.config.tableIds.tachesInternes}`
+      `/${this.config.tableIds.tachesInternes}`,
+      {},
+      0,
+      !forceRefresh
     );
     let list = response.list || [];
 


### PR DESCRIPTION
## Summary
- force refresh task and prospect lists after backfill
- allow internal and client task queries to bypass cache
- refresh global stats using latest tasks

## Testing
- `npm run lint` *(fails: Unexpected any etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c576de6480832dad27675d4a71d7e2