### PR TITLE
Filter tasks by current user in NocoDB query

### DIFF
--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -543,9 +543,16 @@ class NocoDBService {
       return { list: [], pageInfo: { totalRows: 0 } };
     }
 
-    const endpoint = projetId
-      ? `/${this.config.tableIds.taches}?where=(projet_id,eq,${projetId})`
-      : `/${this.config.tableIds.taches}`;
+    let where = "";
+    if (projetId) {
+      where = `(projet_id,eq,${projetId})`;
+    }
+    if (options.onlyCurrentUser && currentUserId) {
+      where += where
+        ? `~and(supabase_user_id,eq,${currentUserId})`
+        : `(supabase_user_id,eq,${currentUserId})`;
+    }
+    const endpoint = `/${this.config.tableIds.taches}` + (where ? `?where=${where}` : "");
 
     const response = await this.makeRequest(endpoint);
     let list = response.list || [];


### PR DESCRIPTION
## Summary
- Apply `supabase_user_id` filter directly in getTasks query when onlyCurrentUser is true

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 154 problems)*
- `npx eslint src/services/nocodbService.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c577308514832dbc09836ea8ca9be6