### PR TITLE
Expose full project tasks in client space context

### DIFF
--- a/src/contexts/ClientSpaceContext.tsx
+++ b/src/contexts/ClientSpaceContext.tsx
@@ -99,7 +99,8 @@ export const ClientSpaceProvider: React.FC<{
           milestones: milestonesResponse,
           invoices: invoicesResponse,
         } = await nocodbService.getSpaceData(spaceId, isClient, {
-          onlyCurrentUser: !isClient,
+          // Inclure toutes les tâches du projet, sans filtrer par utilisateur
+          onlyCurrentUser: false,
         });
 
         // Normaliser les données - inclure TOUTES les tâches (admin et client)


### PR DESCRIPTION
## Summary
- stop filtering client space tasks by current user

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any, no-empty, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c57b7a98ac832d89aa052d60a09c54