### PR TITLE
feat: include all workspace tasks in stats

### DIFF
--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -47,9 +47,9 @@ export const useGlobalStats = () => {
         console.log('📊 Chargement des statistiques globales...');
         
         // Charger les données en parallèle pour accélérer l'affichage des statistiques
-        // Récupérer uniquement les tâches de l'utilisateur courant
+        // Récupérer toutes les tâches accessibles dans les espaces de travail
         const [tasksResponse, milestonesResponse, invoicesResponse] = await Promise.all([
-          nocodbService.getTasks(undefined, { onlyCurrentUser: true }),
+          nocodbService.getTasks(),
           nocodbService.getMilestones(),
           nocodbService.getInvoices()
         ]);


### PR DESCRIPTION
## Summary
- load all accessible tasks for global stats
- update comment to reflect fetching tasks from all workspaces

## Testing
- `npm run lint` *(fails: Unexpected any. Specify a different type)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c57c1fd4d4832d9f28c5d891658500