### PR TITLE
feat: add cache bypass for internal tasks

### DIFF
--- a/src/pages/Tasky.tsx
+++ b/src/pages/Tasky.tsx
@@ -210,7 +210,7 @@ const Tasky = () => {
       try {
         let list: any[] = [];
         if (taskScope === 'internal') {
-          const res = await nocodbService.getInternalTasks({ onlyCurrentUser: true });
+          const res = await nocodbService.getInternalTasks(false, { onlyCurrentUser: true });
           list = res.list || [];
         } else {
           const res = await nocodbService.getTasks(undefined, { onlyCurrentUser: true });

--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -110,7 +110,7 @@ class NocoDBService {
 
   // Cache agressif pour NocoDB gratuit - minimiser les appels
   private static requestCache = new Map<string, { data: any; timestamp: number }>();
-  private static readonly CACHE_DURATION = 300000; // 5 minutes pour réduire drastiquement les appels
+  private static readonly CACHE_DURATION = 60000; // 1 minute pour limiter la latence des données
   private static ongoingRequests = new Map<string, Promise<any>>(); // Éviter les doublons
 
   private invalidateCache(endpoint: string) {
@@ -674,13 +674,16 @@ class NocoDBService {
   }
 
   // Tâches internes
-  async getInternalTasks(options: { onlyCurrentUser?: boolean } = {}) {
+  async getInternalTasks(forceRefresh = false, options: { onlyCurrentUser?: boolean } = {}) {
     const currentUserId = options.onlyCurrentUser
       ? await this.getCurrentUserId()
       : null;
 
     const response = await this.makeRequest(
-      `/${this.config.tableIds.tachesInternes}`
+      `/${this.config.tableIds.tachesInternes}`,
+      {},
+      0,
+      !forceRefresh
     );
     let list = response.list || [];
 


### PR DESCRIPTION
## Summary
- reduce NocoDB cache TTL to 1 minute
- allow skipping cache when fetching internal tasks

## Testing
- `npm run lint` (fails: @typescript-eslint/no-explicit-any and others)
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c57ea2108c832d8e4134046ed66390