### PR TITLE
Normalize task field names and streamline assignee filters

### DIFF
--- a/src/components/tasks/ClientTaskManager.tsx
+++ b/src/components/tasks/ClientTaskManager.tsx
@@ -32,7 +32,18 @@ const ClientTaskManager = ({ spaceId }: ClientTaskManagerProps) => {
     const loadTasks = async () => {
       try {
         const response = await nocodbService.getTasksPublic(spaceId);
-        setTasks(response?.list || []);
+        const tasks = (response?.list || []).map((t: Record<string, unknown>) => ({
+          ...t,
+          assigne_a:
+            (t['assigne_a'] as string | undefined) ||
+            (t['assigné_a'] as string | undefined) ||
+            'moi',
+          priorite:
+            (t['priorite'] as string | undefined) ||
+            (t['priorité'] as string | undefined) ||
+            'moyenne'
+        })) as Task[];
+        setTasks(tasks);
       } catch (error) {
         console.error('Erreur lors du chargement des tâches:', error);
         toast({
@@ -151,8 +162,8 @@ const ClientTaskManager = ({ spaceId }: ClientTaskManagerProps) => {
   }
 
   // Séparer les tâches client et admin
-  const clientTasks = tasks.filter(task => (task.assigne_a || task['assigné_a']) === 'client');
-  const adminTasks = tasks.filter(task => (task.assigne_a || task['assigné_a']) === 'moi');
+  const clientTasks = tasks.filter(task => task.assigne_a === 'client');
+  const adminTasks = tasks.filter(task => task.assigne_a === 'moi');
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- Normalize task data from public API to always provide `assigne_a` and `priorite`
- Simplify client/admin task filters to use `assigne_a`

## Testing
- `npx eslint src/components/tasks/ClientTaskManager.tsx`
- `npm run build`
- `npm run lint` *(fails: Unexpected any, no-empty, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c585f30194832dbdecee761daad51a