### PR TITLE
Handle multiple task ID fields in cache updates

### DIFF
--- a/src/contexts/ClientSpaceContext.tsx
+++ b/src/contexts/ClientSpaceContext.tsx
@@ -203,8 +203,8 @@ export const ClientSpaceProvider: React.FC<{
 
   const updateTaskInCache = (taskId: string, updates: Partial<Task>) => {
     setData(prev => {
-      const updatedTasks = prev.tasks.map(task => 
-        task.Id === taskId ? { ...task, ...updates } : task
+      const updatedTasks = prev.tasks.map(task =>
+        task.Id === taskId || task.id === taskId ? { ...task, ...updates } : task
       );
       
       const updatedData = { ...prev, tasks: updatedTasks };

--- a/src/hooks/useSpaceData.ts
+++ b/src/hooks/useSpaceData.ts
@@ -203,10 +203,9 @@ export const useSpaceData = (spaceId: string, isPublic = false) => {
   const updateTaskInCache = (taskId: string, updates: Partial<Task>) => {
     const cached = spaceDataCache.get(spaceId);
     if (cached) {
-      const updatedTasks = cached.data.tasks.map(task => {
-        const idMatch = (task.Id || task.id) === taskId;
-        return idMatch ? { ...task, ...updates } : task;
-      });
+      const updatedTasks = cached.data.tasks.map(task =>
+        task.Id === taskId || task.id === taskId ? { ...task, ...updates } : task
+      );
       const updatedData = { ...cached.data, tasks: updatedTasks };
       spaceDataCache.set(spaceId, { data: updatedData, timestamp: Date.now() });
       setData(updatedData);


### PR DESCRIPTION
## Summary
- Match task updates using either `Id` or `id` in ClientSpace cache
- Use the same dual-ID check when updating tasks in useSpaceData

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 132 errors, 17 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c585f3b058832da6bc209dce0e1160