### PR TITLE
refactor: remove nocodb backfill calls

### DIFF
--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -37,13 +37,6 @@ export const useGlobalStats = () => {
       setStats(prev => ({ ...prev, isLoading: true }));
 
       try {
-        // S'assurer que toutes les tâches de l'utilisateur courant sont correctement assignées
-        await nocodbService.backfillTasksForCurrentUser();
-        const anyService = nocodbService as any;
-        if (typeof anyService.backfillProspectsForCurrentUser === 'function') {
-          await anyService.backfillProspectsForCurrentUser();
-        }
-
         console.log('📊 Chargement des statistiques globales...');
         
         // Charger les données en parallèle pour accélérer l'affichage des statistiques

--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -54,18 +54,6 @@ const Pipou = () => {
   const [milestonesProject, setMilestonesProject] = useState<Project | null>(null);
   const [invoicesProject, setInvoicesProject] = useState<Project | null>(null);
 
-  // Backfill des anciens prospects vers le compte courant
-  useEffect(() => {
-    const runBackfill = async () => {
-      try {
-        await nocodbService.backfillProspectsForCurrentUser();
-      } catch (e) {
-        console.warn('Backfill prospects échoué:', e);
-      }
-    };
-    runBackfill();
-  }, []);
-
   const loadProjects = useCallback(
     async (forceRefresh = false) => {
       try {
@@ -151,12 +139,6 @@ const Pipou = () => {
     async (forceRefresh = false) => {
       setIsLoadingProspects(true);
       try {
-        await nocodbService.backfillTasksForCurrentUser();
-        const anyService = nocodbService as any;
-        if (typeof anyService.backfillProspectsForCurrentUser === 'function') {
-          await anyService.backfillProspectsForCurrentUser();
-        }
-
         const response = await nocodbService.getProspects(
           PROSPECTS_PAGE_SIZE,
           forceRefresh ? 0 : prospectOffset,

--- a/src/pages/Tasky.tsx
+++ b/src/pages/Tasky.tsx
@@ -81,21 +81,6 @@ const Tasky = () => {
     console.log('🚀 Tasky refactorisé - Plus de localStorage');
   }, []);
 
-  // Backfill des anciennes tâches vers votre compte (une fois au montage)
-  useEffect(() => {
-    const runBackfill = async () => {
-      try {
-        const res = await nocodbService.backfillTasksForCurrentUser();
-        if ((res?.updatedClientTasks || 0) + (res?.updatedInternalTasks || 0) > 0) {
-          setRefreshTick(t => t + 1);
-        }
-      } catch (e) {
-        console.warn('Backfill tâches échoué:', e);
-      }
-    };
-    runBackfill();
-  }, []);
-
   // Charger les projets depuis NocoDB
   useEffect(() => {
     const loadProjects = async () => {


### PR DESCRIPTION
## Summary
- remove nocodb backfill calls from global stats hook
- drop backfill usage in Pipou prospection page
- delete task backfill logic from Tasky page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 146 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c587317768832d87376d0c591742bb