### PR TITLE
refactor: call nocodb prospect backfill directly

### DIFF
--- a/src/hooks/useGlobalStats.ts
+++ b/src/hooks/useGlobalStats.ts
@@ -39,10 +39,7 @@ export const useGlobalStats = () => {
       try {
         // S'assurer que toutes les tâches de l'utilisateur courant sont correctement assignées
         await nocodbService.backfillTasksForCurrentUser();
-        const anyService = nocodbService as any;
-        if (typeof anyService.backfillProspectsForCurrentUser === 'function') {
-          await anyService.backfillProspectsForCurrentUser();
-        }
+        await nocodbService.backfillProspectsForCurrentUser();
 
         console.log('📊 Chargement des statistiques globales...');
         

--- a/src/pages/Pipou.tsx
+++ b/src/pages/Pipou.tsx
@@ -152,10 +152,7 @@ const Pipou = () => {
       setIsLoadingProspects(true);
       try {
         await nocodbService.backfillTasksForCurrentUser();
-        const anyService = nocodbService as any;
-        if (typeof anyService.backfillProspectsForCurrentUser === 'function') {
-          await anyService.backfillProspectsForCurrentUser();
-        }
+        await nocodbService.backfillProspectsForCurrentUser();
 
         const response = await nocodbService.getProspects(
           PROSPECTS_PAGE_SIZE,


### PR DESCRIPTION
## Summary
- simplify global stats hook by calling nocodb prospect backfill directly
- call nocodb prospect backfill directly in Pipou page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 147 problems (130 errors, 17 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68c5873285c8832d842248c702b79925