### PR TITLE
Allow global task retrieval in NocoDB service

### DIFF
--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -603,10 +603,7 @@ class NocoDBService {
     }
 
     // If user has no accessible projects and no specific project requested,
-    // return empty only when not filtering for the current user
-    if (!projetId && userProjectIds.length === 0 && !options.onlyCurrentUser) {
-      return { list: [], pageInfo: { totalRows: 0 } };
-    }
+    // still retrieve tasks and filter only if we actually have project ids
 
     const projetIdStr = projetId?.toString();
     const endpoint = projetIdStr


### PR DESCRIPTION
## Summary
- remove early return when no project IDs are available
- ensure tasks are always fetched and only filtered if project list exists

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 148 problems)


------
https://chatgpt.com/codex/tasks/task_e_68c599409bc8832db0a1c3cca17431fe