### PR TITLE
fix: refine invoice access checks

### DIFF
--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -938,7 +938,7 @@ class NocoDBService {
         .map((p: any) => (p.Id || p.id)?.toString())
         .filter(Boolean);
 
-    if (projetId && !projectIds.includes(projetId)) {
+    if (projetId && projectIds.length > 0 && !projectIds.includes(projetId)) {
       // User doesn't own this project, return empty
       return { list: [], pageInfo: { totalRows: 0 } };
     }
@@ -950,15 +950,18 @@ class NocoDBService {
     const response = await this.fetchAllRecords(endpoint);
 
     if (!projetId) {
-      // Filter invoices by user's owned spaces
-      const filteredList = (response.list || []).filter((invoice: any) =>
-        userSpaceIds.includes(invoice.projet_id?.toString())
-      );
-      return {
-        ...response,
-        list: filteredList,
-        pageInfo: { ...response.pageInfo, totalRows: filteredList.length }
-      };
+      if (userSpaceIds.length > 0) {
+        // Filter invoices by user's owned spaces
+        const filteredList = (response.list || []).filter((invoice: any) =>
+          userSpaceIds.includes(invoice.projet_id?.toString())
+        );
+        return {
+          ...response,
+          list: filteredList,
+          pageInfo: { ...response.pageInfo, totalRows: filteredList.length }
+        };
+      }
+      return response;
     }
 
     return response;


### PR DESCRIPTION
## Summary
- skip project ownership check when no projects known
- only filter invoices by user space when user spaces exist

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any, A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c59b1ba4d8832d8afd3dcd0dc7d430