### PR TITLE
fix: handle empty project and space filters in milestones

### DIFF
--- a/src/services/nocodbService.ts
+++ b/src/services/nocodbService.ts
@@ -882,7 +882,7 @@ class NocoDBService {
         .map((p: any) => (p.Id || p.id)?.toString())
         .filter(Boolean);
 
-    if (projetId && !projectIds.includes(projetId)) {
+    if (projetId && projectIds.length > 0 && !projectIds.includes(projetId)) {
       // User doesn't own this project, return empty
       return { list: [], pageInfo: { totalRows: 0 } };
     }
@@ -894,7 +894,7 @@ class NocoDBService {
 
     const response = await this.fetchAllRecords(endpoint);
 
-    if (!projetId) {
+    if (!projetId && userSpaceIds.length > 0) {
       // Filter milestones by user's owned spaces
       const filteredList = (response.list || []).filter((milestone: any) =>
         userSpaceIds.includes(milestone.projet_id?.toString())


### PR DESCRIPTION
## Summary
- avoid rejecting milestones when project cache is empty
- skip user space filtering when no space IDs are available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 148 problems)*
- `npx eslint src/services/nocodbService.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c59b1abd38832d8f7adeb19e0f58f9